### PR TITLE
feat: 분석 기록 삭제 기능 추가

### DIFF
--- a/frontend/src/app/components/AnalysisHistory.tsx
+++ b/frontend/src/app/components/AnalysisHistory.tsx
@@ -1,18 +1,29 @@
 import { useState } from 'react';
-import { Eye, Edit2, Check, X, Search, Calendar, Maximize2, Minimize2 } from 'lucide-react';
+import { Eye, Edit2, Check, X, Search, Calendar, Maximize2, Minimize2, Trash2 } from 'lucide-react';
 import { DayPicker, DateRange } from 'react-day-picker';
 import { format, isWithinInterval, parseISO } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { AnalysisRecord } from './Dashboard';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from './ui/alert-dialog';
 
 interface AnalysisHistoryProps {
   records: AnalysisRecord[];
   selectedJobId: string | null;
   onSelectJob: (jobId: string) => void;
   onRenameVideo: (jobId: string, newTitle: string) => void;
+  onDeleteRecord: (jobId: string) => void;
 }
 
-export function AnalysisHistory({ records, selectedJobId, onSelectJob, onRenameVideo }: AnalysisHistoryProps) {
+export function AnalysisHistory({ records, selectedJobId, onSelectJob, onRenameVideo, onDeleteRecord }: AnalysisHistoryProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
@@ -21,6 +32,8 @@ export function AnalysisHistory({ records, selectedJobId, onSelectJob, onRenameV
   const [accidentDateRange, setAccidentDateRange] = useState<DateRange | undefined>();
   const [uploadDateRange, setUploadDateRange] = useState<DateRange | undefined>();
   const [isExpanded, setIsExpanded] = useState(false);
+  // 삭제 확인 다이얼로그용: 삭제 대기 중인 기록
+  const [deletingRecord, setDeletingRecord] = useState<AnalysisRecord | null>(null);
 
   const getStatusColor = (status: AnalysisRecord['status']) => {
     switch (status) {
@@ -263,16 +276,26 @@ export function AnalysisHistory({ records, selectedJobId, onSelectJob, onRenameV
                       </div>
                     </td>
 
-                    {/* 보기 버튼 */}
+                    {/* 보기 / 삭제 버튼 */}
                     <td className="py-3 px-4">
-                      <button
-                        onClick={() => { onSelectJob(record.jobId); setIsExpanded(false); }}
-                        className="flex items-center gap-2 px-4 py-1 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed"
-                        disabled={record.status !== 'COMPLETED'}
-                      >
-                        <Eye className="w-4 h-4" />
-                        보기
-                      </button>
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={() => { onSelectJob(record.jobId); setIsExpanded(false); }}
+                          className="flex items-center gap-2 px-4 py-1 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed"
+                          disabled={record.status !== 'COMPLETED'}
+                        >
+                          <Eye className="w-4 h-4" />
+                          보기
+                        </button>
+                        <button
+                          onClick={() => setDeletingRecord(record)}
+                          className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded transition-colors"
+                          title="삭제"
+                          aria-label="분석 기록 삭제"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
                     </td>
                   </tr>
                 ))}
@@ -309,6 +332,36 @@ export function AnalysisHistory({ records, selectedJobId, onSelectJob, onRenameV
           </div>
         </div>
       )}
+
+      {/* 삭제 확인 다이얼로그 */}
+      <AlertDialog
+        open={deletingRecord !== null}
+        onOpenChange={(open) => { if (!open) setDeletingRecord(null); }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>분석 기록을 삭제하시겠습니까?</AlertDialogTitle>
+            <AlertDialogDescription>
+              <span className="font-medium text-gray-900">
+                "{deletingRecord?.customTitle || '(제목 없음)'}"
+              </span>
+              {' '}기록이 영구적으로 삭제됩니다. 이 작업은 되돌릴 수 없습니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (deletingRecord) onDeleteRecord(deletingRecord.jobId);
+                setDeletingRecord(null);
+              }}
+              className="bg-red-600 hover:bg-red-700 text-white"
+            >
+              삭제
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }

--- a/frontend/src/app/components/Dashboard.tsx
+++ b/frontend/src/app/components/Dashboard.tsx
@@ -172,6 +172,28 @@ export function Dashboard() {
     }
   };
 
+  // 분석 기록 삭제 → 백엔드 호출 (데모면 로컬만 제거)
+  const handleDeleteRecord = async (jobId: string) => {
+    // 삭제하려는 기록이 현재 선택된 항목이면 선택 해제 (3D 뷰어 닫기)
+    if (selectedJobId === jobId) {
+      setSelectedJobId(null);
+    }
+
+    if (isDemo) {
+      setRecords(prev => prev.filter(r => r.jobId !== jobId));
+      toast.success('삭제되었습니다.');
+      return;
+    }
+    try {
+      await apiClient.delete(`/api/v1/reconstruction/${jobId}`);
+      setRecords(prev => prev.filter(r => r.jobId !== jobId));
+      toast.success('삭제되었습니다.');
+    } catch (err) {
+      console.error('삭제 실패:', err);
+      toast.error('삭제에 실패했습니다.');
+    }
+  };
+
   // 드래그 앤 드롭 업로드
   const handleDrop = async (e: React.DragEvent) => {
     e.preventDefault();
@@ -302,6 +324,7 @@ export function Dashboard() {
             selectedJobId={selectedJobId}
             onSelectJob={setSelectedJobId}
             onRenameVideo={handleRenameVideo}
+            onDeleteRecord={handleDeleteRecord}
           />
         )}
 


### PR DESCRIPTION
## 🔎개요
분석 기록을 사용자가 직접 삭제할 수 있는 기능을 추가했습니다.


## 📝작업 내용
- AnalysisHistory 작업 컬럼에 휴지통 버튼 추가 (빨간 호버)
- 삭제 클릭 시 AlertDialog 확인 다이얼로그 → 영상명 표시 후 "삭제"/"취소"
- Dashboard에 handleDeleteRecord 핸들러: `DELETE /api/v1/reconstruction/{jobId}` 호출
- 삭제 시 선택된 항목이면 자동으로 선택 해제(3D 뷰어 닫힘)
- 데모 모드는 로컬 state에서만 제거


## 👀변경 사항
- `frontend/src/app/components/Dashboard.tsx`
- `frontend/src/app/components/AnalysisHistory.tsx`
- 백엔드 `DELETE /api/v1/reconstruction/{jobId}` 엔드포인트 필요