### PR TITLE
feat: 영상명 검색을 서버사이드로 전환

### DIFF
--- a/frontend/src/app/components/AnalysisHistory.tsx
+++ b/frontend/src/app/components/AnalysisHistory.tsx
@@ -21,9 +21,11 @@ interface AnalysisHistoryProps {
   onSelectJob: (jobId: string) => void;
   onRenameVideo: (jobId: string, newTitle: string) => void;
   onDeleteRecord: (jobId: string) => void;
+  // 검색어 변경을 부모(Dashboard)에 통지 → 부모에서 디바운스 후 서버에 keyword 전달
+  onSearchChange?: (keyword: string) => void;
 }
 
-export function AnalysisHistory({ records, selectedJobId, onSelectJob, onRenameVideo, onDeleteRecord }: AnalysisHistoryProps) {
+export function AnalysisHistory({ records, selectedJobId, onSelectJob, onRenameVideo, onDeleteRecord, onSearchChange }: AnalysisHistoryProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
@@ -34,6 +36,12 @@ export function AnalysisHistory({ records, selectedJobId, onSelectJob, onRenameV
   const [isExpanded, setIsExpanded] = useState(false);
   // 삭제 확인 다이얼로그용: 삭제 대기 중인 기록
   const [deletingRecord, setDeletingRecord] = useState<AnalysisRecord | null>(null);
+
+  // 검색어 변경 헬퍼: 로컬 state 갱신 + 부모에 통지
+  const updateSearchQuery = (value: string) => {
+    setSearchQuery(value);
+    onSearchChange?.(value);
+  };
 
   const getStatusColor = (status: AnalysisRecord['status']) => {
     switch (status) {
@@ -63,7 +71,7 @@ export function AnalysisHistory({ records, selectedJobId, onSelectJob, onRenameV
     setEditValue('');
   };
 
-  // 필터링
+  // 필터링 (서버사이드 keyword 검색이 적용되더라도 데모/날짜 필터를 위해 클라이언트 필터 유지)
   const filteredRecords = records.filter(record => {
     const matchesSearch = (record.customTitle ?? '').toLowerCase().includes(searchQuery.toLowerCase());
 
@@ -104,7 +112,7 @@ export function AnalysisHistory({ records, selectedJobId, onSelectJob, onRenameV
                 type="text"
                 placeholder="영상명 검색..."
                 value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
+                onChange={(e) => updateSearchQuery(e.target.value)}
                 className="pl-10 pr-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
               />
             </div>
@@ -172,7 +180,7 @@ export function AnalysisHistory({ records, selectedJobId, onSelectJob, onRenameV
 
           {(accidentDateRange?.from || uploadDateRange?.from || searchQuery) && (
             <button
-              onClick={() => { setAccidentDateRange(undefined); setUploadDateRange(undefined); setSearchQuery(''); }}
+              onClick={() => { setAccidentDateRange(undefined); setUploadDateRange(undefined); updateSearchQuery(''); }}
               className="flex items-center gap-2 px-4 py-2 border border-red-300 bg-red-50 text-red-700 rounded-md text-sm hover:bg-red-100 transition-colors"
             >
               <X className="w-4 h-4" />

--- a/frontend/src/app/components/Dashboard.tsx
+++ b/frontend/src/app/components/Dashboard.tsx
@@ -79,6 +79,7 @@ const DEMO_RECORDS: AnalysisRecord[] = [
 ];
 
 const POLL_INTERVAL_MS = 5000;
+const SEARCH_DEBOUNCE_MS = 300;
 
 export function Dashboard() {
   const { user, logout } = useAuth();
@@ -90,18 +91,33 @@ export function Dashboard() {
   const [isLoading, setIsLoading] = useState(true);
   const [isUploading, setIsUploading] = useState(false);
 
+  // 검색어 (AnalysisHistory에서 통지받음) + 디바운스된 값
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [debouncedKeyword, setDebouncedKeyword] = useState('');
+
   const isDemo = user?.userId === 'demo';
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // 분석 기록 목록 조회 (데모면 더미 데이터)
-  const fetchRecords = async () => {
+  // 분석 기록 목록 조회 (데모면 더미 데이터, 실모드면 keyword 서버 전달)
+  const fetchRecords = async (keyword?: string) => {
     if (isDemo) {
       setRecords(DEMO_RECORDS);
       return DEMO_RECORDS;
     }
     try {
-      const res = await apiClient.get<AnalysisRecord[]>('/api/v1/reconstruction');
-      const data = Array.isArray(res.data) ? res.data : [];
+      const params: Record<string, string> = {};
+      if (keyword && keyword.trim()) params.keyword = keyword.trim();
+      const res = await apiClient.get<AnalysisRecord[] | { result: AnalysisRecord[] }>(
+        '/api/v1/reconstruction',
+        { params }
+      );
+      // BaseResponse 래퍼({ result: [...] })와 직접 배열 응답 둘 다 허용
+      const raw = res.data as unknown;
+      const data: AnalysisRecord[] = Array.isArray(raw)
+        ? (raw as AnalysisRecord[])
+        : Array.isArray((raw as { result?: unknown })?.result)
+        ? ((raw as { result: AnalysisRecord[] }).result)
+        : [];
       setRecords(data);
       return data;
     } catch (err) {
@@ -118,7 +134,7 @@ export function Dashboard() {
     if (!hasInProgress) return;
 
     pollTimerRef.current = setTimeout(async () => {
-      const updated = await fetchRecords();
+      const updated = await fetchRecords(debouncedKeyword);
       if (updated) schedulePolling(updated);
     }, POLL_INTERVAL_MS);
   };
@@ -133,12 +149,32 @@ export function Dashboard() {
     return () => {
       if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // 검색어 디바운스: 입력 멈춘 뒤 300ms 후 debouncedKeyword에 반영
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedKeyword(searchKeyword), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [searchKeyword]);
+
+  // 디바운스된 검색어 변경 시 서버 재조회 (데모는 클라이언트 필터로 충분하므로 스킵)
+  useEffect(() => {
+    if (isDemo) return;
+    // 초기 로딩 중에는 위의 첫 useEffect가 처리하므로 중복 호출 방지
+    if (isLoading) return;
+    (async () => {
+      const data = await fetchRecords(debouncedKeyword);
+      if (data) schedulePolling(data);
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedKeyword]);
 
   // 폴링 갱신 시 selectedRecord도 동기화
   useEffect(() => {
     if (!records.length) return;
     schedulePolling(records);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [records]);
 
   // 선택된 jobId에 맞는 record 동기화
@@ -231,7 +267,7 @@ export function Dashboard() {
     try {
       await apiClient.post('/api/v1/reconstruction/upload', formData);
       toast.success('업로드 완료! 분석을 시작합니다.');
-      const data = await fetchRecords();
+      const data = await fetchRecords(debouncedKeyword);
       if (data) schedulePolling(data);
     } catch (err) {
       console.error('업로드 실패:', err);
@@ -325,6 +361,7 @@ export function Dashboard() {
             onSelectJob={setSelectedJobId}
             onRenameVideo={handleRenameVideo}
             onDeleteRecord={handleDeleteRecord}
+            onSearchChange={setSearchKeyword}
           />
         )}
 


### PR DESCRIPTION
## 🔎개요
프론트엔드에서 클라이언트 필터링하던 검색을 백엔드 LIKE 쿼리로 전환했습니다.


## 📝작업 내용
- Dashboard에 `searchKeyword`/`debouncedKeyword` state 추가 (300ms 디바운스)
- AnalysisHistory의 검색 입력이 부모(Dashboard)에 onSearchChange로 통지
- 디바운스된 검색어가 바뀌면 `GET /api/v1/reconstruction?keyword=...` 재호출
- BaseResponse 래퍼(`{ result: [...] }`)와 직접 배열 응답 둘 다 호환되도록 fetchRecords 보강
- 데모 모드는 클라이언트 필터링 유지 (백엔드 호출 안 함)


## 👀변경 사항
- `frontend/src/app/components/Dashboard.tsx`
- `frontend/src/app/components/AnalysisHistory.tsx`
- 백엔드 `GET /api/v1/reconstruction` 의 `?keyword=` 쿼리 파라미터 처리 필요