### PR TITLE
[feat] UI 리디자인 — 랜딩 페이지 추가 및 로그인/대시보드 개편

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+
+  <!DOCTYPE html>
+  <html lang="en">
+    <head>
+      <meta charset="UTF-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <title>ReScene — 사고 장면을, 다시 만들다</title>
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+      <link
+        href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap"
+        rel="stylesheet"
+      />
+      <link
+        href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
+        rel="stylesheet"
+      />
+    </head>
+
+    <body>
+      <div id="root"></div>
+      <script type="module" src="/src/main.tsx"></script>
+    </body>
+  </html>
+  

--- a/src/app/AnalysisHistory.tsx
+++ b/src/app/AnalysisHistory.tsx
@@ -1,0 +1,375 @@
+import { useState } from 'react';
+import { Eye, Edit2, Check, X, Search, Calendar, Maximize2, Minimize2, Trash2 } from 'lucide-react';
+import { DayPicker, DateRange } from 'react-day-picker';
+import { format, isWithinInterval, parseISO } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { AnalysisRecord } from './Dashboard';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from './ui/alert-dialog';
+
+interface AnalysisHistoryProps {
+  records: AnalysisRecord[];
+  selectedJobId: string | null;
+  onSelectJob: (jobId: string) => void;
+  onRenameVideo: (jobId: string, newTitle: string) => void;
+  onDeleteRecord: (jobId: string) => void;
+  // 검색어 변경을 부모(Dashboard)에 통지 → 부모에서 디바운스 후 서버에 keyword 전달
+  onSearchChange?: (keyword: string) => void;
+}
+
+export function AnalysisHistory({ records, selectedJobId, onSelectJob, onRenameVideo, onDeleteRecord, onSearchChange }: AnalysisHistoryProps) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showAccidentDatePicker, setShowAccidentDatePicker] = useState(false);
+  const [showUploadDatePicker, setShowUploadDatePicker] = useState(false);
+  const [accidentDateRange, setAccidentDateRange] = useState<DateRange | undefined>();
+  const [uploadDateRange, setUploadDateRange] = useState<DateRange | undefined>();
+  const [isExpanded, setIsExpanded] = useState(false);
+  // 삭제 확인 다이얼로그용: 삭제 대기 중인 기록
+  const [deletingRecord, setDeletingRecord] = useState<AnalysisRecord | null>(null);
+
+  // 검색어 변경 헬퍼: 로컬 state 갱신 + 부모에 통지
+  const updateSearchQuery = (value: string) => {
+    setSearchQuery(value);
+    onSearchChange?.(value);
+  };
+
+  const getStatusColor = (status: AnalysisRecord['status']) => {
+    switch (status) {
+      case 'COMPLETED':         return 'text-[#299283] bg-[#e6f5f2]';
+      case 'PROCESSING':
+      case 'PRE_PROCESSING':    return 'text-[#299283] bg-[#e6f5f2]';
+      case 'WAITING_FOR_TARGET':return 'text-[#c4851c] bg-[#fdf4e3]';
+      case 'PENDING':           return 'text-[#5a665e] bg-[#f7f9f8]';
+      case 'FAILED':            return 'text-[#c44040] bg-[#fbe9e9]';
+    }
+  };
+
+  const startEditing = (record: AnalysisRecord) => {
+    setEditingId(record.jobId);
+    setEditValue(record.customTitle ?? '');
+  };
+
+  const saveEdit = (jobId: string) => {
+    if (editValue.trim()) {
+      onRenameVideo(jobId, editValue.trim());
+    }
+    setEditingId(null);
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditValue('');
+  };
+
+  // 필터링 (서버사이드 keyword 검색이 적용되더라도 데모/날짜 필터를 위해 클라이언트 필터 유지)
+  const filteredRecords = records.filter(record => {
+    const matchesSearch = (record.customTitle ?? '').toLowerCase().includes(searchQuery.toLowerCase());
+
+    let matchesAccidentDate = true;
+    if (accidentDateRange?.from && record.incidentDate) {
+      const d = parseISO(record.incidentDate);
+      matchesAccidentDate = accidentDateRange.to
+        ? isWithinInterval(d, { start: accidentDateRange.from, end: accidentDateRange.to })
+        : format(d, 'yyyy-MM-dd') === format(accidentDateRange.from, 'yyyy-MM-dd');
+    }
+
+    let matchesUploadDate = true;
+    if (uploadDateRange?.from && record.createdAt) {
+      const d = parseISO(record.createdAt);
+      matchesUploadDate = uploadDateRange.to
+        ? isWithinInterval(d, { start: uploadDateRange.from, end: uploadDateRange.to })
+        : format(d, 'yyyy-MM-dd') === format(uploadDateRange.from, 'yyyy-MM-dd');
+    }
+
+    return matchesSearch && matchesAccidentDate && matchesUploadDate;
+  });
+
+  const formatDateRange = (range: DateRange | undefined) => {
+    if (!range?.from) return '날짜 선택';
+    if (!range.to) return format(range.from, 'yyyy-MM-dd');
+    return `${format(range.from, 'yyyy-MM-dd')} ~ ${format(range.to, 'yyyy-MM-dd')}`;
+  };
+
+  const renderTableContent = () => (
+    <>
+      <div className="flex flex-col gap-3 mb-4">
+        <div className="flex flex-wrap justify-between items-center gap-3">
+          <div className="relative flex-1 min-w-[200px] max-w-[320px]">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-[#b8c4be]" />
+            <input
+              type="text"
+              placeholder="영상명 검색..."
+              value={searchQuery}
+              onChange={(e) => updateSearchQuery(e.target.value)}
+              className="w-full pl-9 pr-3 py-2 bg-[#f7f9f8] border border-[#dae3dd] rounded-lg focus:outline-none focus:bg-white focus:border-[#299283] focus:ring-2 focus:ring-[#299283]/15 text-[13px] transition-all"
+            />
+          </div>
+          {!isExpanded && (
+            <button
+              onClick={() => setIsExpanded(true)}
+              className="flex items-center gap-1.5 px-3 py-2 text-[13px] text-[#5a665e] hover:text-[#20543d] hover:bg-[#eef2f0] rounded-md transition-colors"
+            >
+              <Maximize2 className="w-3.5 h-3.5" />
+              전체 보기
+            </button>
+          )}
+        </div>
+
+        {/* 날짜 필터 */}
+        <div className="flex flex-wrap gap-3">
+          <div className="relative">
+            <button
+              onClick={() => { setShowAccidentDatePicker(!showAccidentDatePicker); setShowUploadDatePicker(false); }}
+              className={`flex items-center gap-2 px-4 py-2 border rounded-md text-sm transition-colors ${
+                accidentDateRange?.from
+                  ? 'border-[#299283] bg-[#e6f5f2] text-[#1a5f54]'
+                  : 'border-[#b8c4be] bg-white text-[#5a665e] hover:bg-[#f7f9f8]'
+              }`}
+            >
+              <Calendar className="w-4 h-4" />
+              <span>사고 날짜: {formatDateRange(accidentDateRange)}</span>
+            </button>
+            {showAccidentDatePicker && (
+              <div className="absolute top-full mt-2 z-20 bg-white border border-[#dae3dd] rounded-lg shadow-lg p-3">
+                <div className="flex justify-between items-center mb-2">
+                  <span className="text-sm text-[#5a665e]">사고 날짜 범위 선택</span>
+                  <button onClick={() => setAccidentDateRange(undefined)} className="text-xs text-[#8a9590] hover:text-[#c44040]">초기화</button>
+                </div>
+                <DayPicker mode="range" selected={accidentDateRange} onSelect={setAccidentDateRange} locale={ko} className="rdp-custom" />
+                <button onClick={() => setShowAccidentDatePicker(false)} className="w-full mt-2 px-4 py-2 bg-[#299283] text-white rounded-md hover:bg-[#1a5f54] text-sm">적용</button>
+              </div>
+            )}
+          </div>
+
+          <div className="relative">
+            <button
+              onClick={() => { setShowUploadDatePicker(!showUploadDatePicker); setShowAccidentDatePicker(false); }}
+              className={`flex items-center gap-2 px-4 py-2 border rounded-md text-sm transition-colors ${
+                uploadDateRange?.from
+                  ? 'border-[#299283] bg-[#e6f5f2] text-[#1a5f54]'
+                  : 'border-[#b8c4be] bg-white text-[#5a665e] hover:bg-[#f7f9f8]'
+              }`}
+            >
+              <Calendar className="w-4 h-4" />
+              <span>업로드 날짜: {formatDateRange(uploadDateRange)}</span>
+            </button>
+            {showUploadDatePicker && (
+              <div className="absolute top-full mt-2 z-20 bg-white border border-[#dae3dd] rounded-lg shadow-lg p-3">
+                <div className="flex justify-between items-center mb-2">
+                  <span className="text-sm text-[#5a665e]">업로드 날짜 범위 선택</span>
+                  <button onClick={() => setUploadDateRange(undefined)} className="text-xs text-[#8a9590] hover:text-[#c44040]">초기화</button>
+                </div>
+                <DayPicker mode="range" selected={uploadDateRange} onSelect={setUploadDateRange} locale={ko} className="rdp-custom" />
+                <button onClick={() => setShowUploadDatePicker(false)} className="w-full mt-2 px-4 py-2 bg-[#299283] text-white rounded-md hover:bg-[#1a5f54] text-sm">적용</button>
+              </div>
+            )}
+          </div>
+
+          {(accidentDateRange?.from || uploadDateRange?.from || searchQuery) && (
+            <button
+              onClick={() => { setAccidentDateRange(undefined); setUploadDateRange(undefined); updateSearchQuery(''); }}
+              className="flex items-center gap-2 px-4 py-2 border border-[#e8a7a7] bg-[#fbe9e9] text-[#a83434] rounded-md text-sm hover:bg-[#f7d6d6] transition-colors"
+            >
+              <X className="w-4 h-4" />
+              모든 필터 초기화
+            </button>
+          )}
+        </div>
+      </div>
+
+      {filteredRecords.length === 0 ? (
+        <div className="text-center py-8 text-[#8a9590]">
+          {searchQuery || accidentDateRange?.from || uploadDateRange?.from
+            ? '검색 결과가 없습니다.'
+            : '분석 기록이 없습니다.'}
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <div className={isExpanded ? 'max-h-[70vh] overflow-y-auto' : 'max-h-[400px] overflow-y-auto'}>
+            <table className="w-full">
+              <thead className="sticky top-0 bg-white z-10 shadow-sm">
+                <tr className="border-b border-[#dae3dd]">
+                  <th className="text-left py-3 px-4 text-[#5a665e]">영상명</th>
+                  <th className="text-left py-3 px-4 text-[#5a665e]">업로드 날짜</th>
+                  <th className="text-left py-3 px-4 text-[#5a665e]">사고 날짜</th>
+                  <th className="text-left py-3 px-4 text-[#5a665e]">상태</th>
+                  <th className="text-left py-3 px-4 text-[#5a665e]">작업</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredRecords.map((record) => (
+                  <tr
+                    key={record.jobId}
+                    className={`border-b border-[#eef2f0] hover:bg-[#f7f9f8] transition-colors ${
+                      selectedJobId === record.jobId ? 'bg-[#e6f5f2]' : ''
+                    }`}
+                  >
+                    {/* 영상명 (편집 가능) */}
+                    <td className="py-3 px-4">
+                      {editingId === record.jobId ? (
+                        <div className="flex items-center gap-2">
+                          <input
+                            type="text"
+                            value={editValue}
+                            onChange={(e) => setEditValue(e.target.value)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') saveEdit(record.jobId);
+                              if (e.key === 'Escape') cancelEdit();
+                            }}
+                            className="flex-1 px-2 py-1 border border-[#299283] rounded focus:outline-none focus:ring-2 focus:ring-[#299283]"
+                            autoFocus
+                          />
+                          <button onClick={() => saveEdit(record.jobId)} className="p-1 text-[#299283] hover:bg-[#e6f5f2] rounded" title="저장">
+                            <Check className="w-4 h-4" />
+                          </button>
+                          <button onClick={cancelEdit} className="p-1 text-[#c44040] hover:bg-[#fbe9e9] rounded" title="취소">
+                            <X className="w-4 h-4" />
+                          </button>
+                        </div>
+                      ) : (
+                        <div className="flex items-center gap-2">
+                          <span className="text-[#20543d]">{record.customTitle || '(제목 없음)'}</span>
+                          <button
+                            onClick={() => startEditing(record)}
+                            className="p-1 text-[#b8c4be] hover:text-[#299283] hover:bg-[#e6f5f2] rounded transition-colors"
+                            title="이름 변경"
+                          >
+                            <Edit2 className="w-4 h-4" />
+                          </button>
+                        </div>
+                      )}
+                    </td>
+
+                    {/* 업로드 날짜 */}
+                    <td className="py-3 px-4 text-[#5a665e]">
+                      {record.createdAt ? record.createdAt.slice(0, 10) : '-'}
+                    </td>
+
+                    {/* 사고 날짜 */}
+                    <td className="py-3 px-4 text-[#20543d]">
+                      {record.incidentDate ? record.incidentDate.slice(0, 10) : '-'}
+                    </td>
+
+                    {/* 상태 */}
+                    <td className="py-3 px-4">
+                      <div className="flex flex-col gap-1">
+                        <span className={`px-3 py-1 rounded-full text-sm w-fit ${getStatusColor(record.status)}`}>
+                          {record.statusDescription || record.status}
+                        </span>
+                        {/* 진행 중일 때 진행률 표시 */}
+                        {(record.status === 'PROCESSING' || record.status === 'PRE_PROCESSING') && (
+                          <div className="flex items-center gap-2">
+                            <div className="w-24 h-1.5 bg-[#dae3dd] rounded-full overflow-hidden">
+                              <div
+                                className="h-full bg-[#e6f5f2]0 rounded-full transition-all"
+                                style={{ width: `${record.progress}%` }}
+                              />
+                            </div>
+                            <span className="text-xs text-[#8a9590]">{record.progress}%</span>
+                          </div>
+                        )}
+                      </div>
+                    </td>
+
+                    {/* 보기 / 삭제 버튼 */}
+                    <td className="py-3 px-4">
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={() => { onSelectJob(record.jobId); setIsExpanded(false); }}
+                          className="flex items-center gap-2 px-4 py-1 bg-[#299283] text-white rounded-md hover:bg-[#1a5f54] transition-colors disabled:bg-[#b8c4be] disabled:cursor-not-allowed"
+                          disabled={record.status !== 'COMPLETED'}
+                        >
+                          <Eye className="w-4 h-4" />
+                          보기
+                        </button>
+                        <button
+                          onClick={() => setDeletingRecord(record)}
+                          className="p-1.5 text-[#b8c4be] hover:text-[#c44040] hover:bg-[#fbe9e9] rounded transition-colors"
+                          title="삭제"
+                          aria-label="분석 기록 삭제"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </>
+  );
+
+  return (
+    <>
+      <div
+        className="bg-white rounded-xl p-5"
+        style={{ border: '1px solid #dae3dd' }}
+      >
+        {renderTableContent()}
+      </div>
+
+      {isExpanded && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-lg shadow-xl w-full max-w-7xl h-[90vh] flex flex-col">
+            <div className="flex justify-between items-center p-6 border-b border-[#dae3dd]">
+              <h2 className="text-2xl text-[#20543d]">나의 분석 기록 - 전체 보기</h2>
+              <button
+                onClick={() => setIsExpanded(false)}
+                className="flex items-center gap-2 px-4 py-2 bg-[#5a665e] text-white rounded-md hover:bg-[#2c3530] transition-colors"
+              >
+                <Minimize2 className="w-4 h-4" />
+                닫기
+              </button>
+            </div>
+            <div className="flex-1 overflow-hidden p-6">
+              {renderTableContent()}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 삭제 확인 다이얼로그 */}
+      <AlertDialog
+        open={deletingRecord !== null}
+        onOpenChange={(open) => { if (!open) setDeletingRecord(null); }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>분석 기록을 삭제하시겠습니까?</AlertDialogTitle>
+            <AlertDialogDescription>
+              <span className="font-medium text-[#20543d]">
+                "{deletingRecord?.customTitle || '(제목 없음)'}"
+              </span>
+              {' '}기록이 영구적으로 삭제됩니다. 이 작업은 되돌릴 수 없습니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (deletingRecord) onDeleteRecord(deletingRecord.jobId);
+                setDeletingRecord(null);
+              }}
+              className="bg-[#c44040] hover:bg-[#a83434] text-white"
+            >
+              삭제
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,0 +1,86 @@
+import { ReactNode } from 'react';
+import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router';
+import { AuthProvider, useAuth } from '../context/AuthContext';
+import { LoginScreen } from './components/LoginScreen';
+import { LandingPage } from './components/LandingPage';
+import { Dashboard } from './components/Dashboard';
+import { OAuthCallback } from './pages/OAuthCallback';
+
+// 로그인한 사용자만 접근 가능한 라우트
+function PrivateRoute({ children }: { children: ReactNode }) {
+  const { user, isLoading } = useAuth();
+  const location = useLocation();
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="w-10 h-10 border-4 border-[#299283] border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (!user) {
+    // 원래 가려던 경로를 state에 저장해서 로그인 후 복원 가능하게
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return <>{children}</>;
+}
+
+// 이미 로그인된 사용자가 /login에 접근하면 /dashboard로
+function PublicRoute({ children }: { children: ReactNode }) {
+  const { user, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="w-10 h-10 border-4 border-[#299283] border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (user) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return <>{children}</>;
+}
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <BrowserRouter>
+        <Routes>
+          {/* 랜딩 페이지 (모두 접근 가능) */}
+          <Route path="/" element={<LandingPage />} />
+
+          {/* 로그인 페이지 (비로그인 전용) */}
+          <Route
+            path="/login"
+            element={
+              <PublicRoute>
+                <LoginScreen />
+              </PublicRoute>
+            }
+          />
+
+          {/* OAuth 콜백 (소셜 로그인 후 백엔드에서 리디렉션되는 경로) */}
+          <Route path="/oauth/callback" element={<OAuthCallback />} />
+
+          {/* 대시보드 (로그인 전용) */}
+          <Route
+            path="/dashboard"
+            element={
+              <PrivateRoute>
+                <Dashboard />
+              </PrivateRoute>
+            }
+          />
+
+          {/* 그 외 경로: 랜딩으로 */}
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </BrowserRouter>
+    </AuthProvider>
+  );
+}

--- a/src/app/Dashboard.tsx
+++ b/src/app/Dashboard.tsx
@@ -1,0 +1,556 @@
+import { useState, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router';
+import { Upload, LogOut, Activity, CheckCircle2, Clock } from 'lucide-react';
+import { toast } from 'sonner';
+import { AnalysisHistory } from './AnalysisHistory';
+import { Viewer3D } from './Viewer3D';
+import { useAuth } from '../../context/AuthContext';
+import apiClient from '../../lib/apiClient';
+
+// 백엔드 JobStatusResponse 필드명에 맞춤
+export interface AnalysisRecord {
+  jobId: string;
+  customTitle: string;
+  status: 'PENDING' | 'PRE_PROCESSING' | 'WAITING_FOR_TARGET' | 'PROCESSING' | 'COMPLETED' | 'FAILED';
+  statusDescription: string;
+  progress: number;
+  currentStep: string;
+  createdAt: string;
+  incidentDate: string;
+  resultUrl?: string;
+  trajectoryUrl?: string;
+}
+
+// userId 기반 일관된 랜덤 닉네임 생성
+function generateNickname(userId: string): string {
+  const adjectives = ['빠른', '느린', '조용한', '활발한', '신중한', '대담한', '차분한', '씩씩한', '영리한', '용감한'];
+  const nouns = ['독수리', '호랑이', '판다', '여우', '늑대', '사자', '고래', '매', '곰', '토끼'];
+  // userId 문자열로 간단한 해시 생성
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = (hash * 31 + userId.charCodeAt(i)) >>> 0;
+  }
+  const adj = adjectives[hash % adjectives.length];
+  const noun = nouns[Math.floor(hash / adjectives.length) % nouns.length];
+  const num = (hash % 9000) + 1000; // 1000~9999
+  return `${adj}${noun}${num}`;
+}
+
+// 폴링이 필요한 상태
+const POLLING_STATUSES: AnalysisRecord['status'][] = [
+  'PENDING',
+  'PRE_PROCESSING',
+  'WAITING_FOR_TARGET',
+  'PROCESSING',
+];
+
+// 데모 사용자용 샘플 데이터
+const DEMO_RECORDS: AnalysisRecord[] = [
+  {
+    jobId: 'demo-1',
+    customTitle: '강남구 사거리 추돌사고',
+    status: 'COMPLETED',
+    statusDescription: '분석 완료',
+    progress: 100,
+    currentStep: '완료',
+    createdAt: '2025-03-10T09:15:00',
+    incidentDate: '2025-03-08T14:30:00',
+    resultUrl: undefined,
+  },
+  {
+    jobId: 'demo-2',
+    customTitle: '고속도로 측면 충돌',
+    status: 'PROCESSING',
+    statusDescription: '3D 복원 중',
+    progress: 62,
+    currentStep: '궤적 계산',
+    createdAt: '2025-03-12T11:00:00',
+    incidentDate: '2025-03-11T08:20:00',
+  },
+  {
+    jobId: 'demo-3',
+    customTitle: '주차장 후진 접촉',
+    status: 'PENDING',
+    statusDescription: '대기 중',
+    progress: 0,
+    currentStep: '대기',
+    createdAt: '2025-03-13T16:45:00',
+    incidentDate: '2025-03-13T15:10:00',
+  },
+];
+
+const POLL_INTERVAL_MS = 5000;
+const SEARCH_DEBOUNCE_MS = 300;
+
+export function Dashboard() {
+  const navigate = useNavigate();
+  const { user, logout } = useAuth();
+
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
+  const [selectedRecord, setSelectedRecord] = useState<AnalysisRecord | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [records, setRecords] = useState<AnalysisRecord[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isUploading, setIsUploading] = useState(false);
+
+  // 검색어 (AnalysisHistory에서 통지받음) + 디바운스된 값
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [debouncedKeyword, setDebouncedKeyword] = useState('');
+
+  const isDemo = user?.userId === 'demo';
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // 분석 기록 목록 조회 (데모면 더미 데이터, 실모드면 keyword 서버 전달)
+  const fetchRecords = async (keyword?: string) => {
+    if (isDemo) {
+      setRecords(DEMO_RECORDS);
+      return DEMO_RECORDS;
+    }
+    try {
+      const params: Record<string, string> = {};
+      if (keyword && keyword.trim()) params.keyword = keyword.trim();
+      const res = await apiClient.get<AnalysisRecord[] | { result: AnalysisRecord[] }>(
+        '/api/v1/reconstruction',
+        { params }
+      );
+      // BaseResponse 래퍼({ result: [...] })와 직접 배열 응답 둘 다 허용
+      const raw = res.data as unknown;
+      const data: AnalysisRecord[] = Array.isArray(raw)
+        ? (raw as AnalysisRecord[])
+        : Array.isArray((raw as { result?: unknown })?.result)
+        ? ((raw as { result: AnalysisRecord[] }).result)
+        : [];
+      setRecords(data);
+      return data;
+    } catch (err) {
+      console.error('목록 조회 실패:', err);
+      return null;
+    }
+  };
+
+  // 폴링: 진행 중인 job이 있으면 5초마다 자동 갱신 (데모는 폴링 안 함)
+  const schedulePolling = (data: AnalysisRecord[]) => {
+    if (isDemo) return;
+    if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
+    const hasInProgress = data.some((r) => POLLING_STATUSES.includes(r.status));
+    if (!hasInProgress) return;
+
+    pollTimerRef.current = setTimeout(async () => {
+      const updated = await fetchRecords(debouncedKeyword);
+      if (updated) schedulePolling(updated);
+    }, POLL_INTERVAL_MS);
+  };
+
+  useEffect(() => {
+    (async () => {
+      const data = await fetchRecords();
+      setIsLoading(false);
+      if (data) schedulePolling(data);
+    })();
+
+    return () => {
+      if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 검색어 디바운스: 입력 멈춘 뒤 300ms 후 debouncedKeyword에 반영
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedKeyword(searchKeyword), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [searchKeyword]);
+
+  // 디바운스된 검색어 변경 시 서버 재조회 (데모는 클라이언트 필터로 충분하므로 스킵)
+  useEffect(() => {
+    if (isDemo) return;
+    // 초기 로딩 중에는 위의 첫 useEffect가 처리하므로 중복 호출 방지
+    if (isLoading) return;
+    (async () => {
+      const data = await fetchRecords(debouncedKeyword);
+      if (data) schedulePolling(data);
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedKeyword]);
+
+  // 폴링 갱신 시 selectedRecord도 동기화
+  useEffect(() => {
+    if (!records.length) return;
+    schedulePolling(records);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [records]);
+
+  // 선택된 jobId에 맞는 record 동기화
+  useEffect(() => {
+    if (selectedJobId) {
+      const found = records.find(r => r.jobId === selectedJobId) ?? null;
+      setSelectedRecord(found);
+    } else {
+      setSelectedRecord(null);
+    }
+  }, [selectedJobId, records]);
+
+  // 이름 변경 → 백엔드 저장 (데모면 로컬만 변경)
+  const handleRenameVideo = async (jobId: string, newTitle: string) => {
+    if (isDemo) {
+      setRecords(prev =>
+        prev.map(r => r.jobId === jobId ? { ...r, customTitle: newTitle } : r)
+      );
+      return;
+    }
+    try {
+      await apiClient.patch(
+        `/api/v1/reconstruction/${jobId}/title?newTitle=${encodeURIComponent(newTitle)}`
+      );
+      setRecords(prev =>
+        prev.map(r => r.jobId === jobId ? { ...r, customTitle: newTitle } : r)
+      );
+    } catch (err) {
+      console.error('이름 변경 실패:', err);
+      toast.error('이름 변경에 실패했습니다.');
+    }
+  };
+
+  // 분석 기록 삭제 → 백엔드 호출 (데모면 로컬만 제거)
+  const handleDeleteRecord = async (jobId: string) => {
+    // 삭제하려는 기록이 현재 선택된 항목이면 선택 해제 (3D 뷰어 닫기)
+    if (selectedJobId === jobId) {
+      setSelectedJobId(null);
+    }
+
+    if (isDemo) {
+      setRecords(prev => prev.filter(r => r.jobId !== jobId));
+      toast.success('삭제되었습니다.');
+      return;
+    }
+    try {
+      await apiClient.delete(`/api/v1/reconstruction/${jobId}`);
+      setRecords(prev => prev.filter(r => r.jobId !== jobId));
+      toast.success('삭제되었습니다.');
+    } catch (err) {
+      console.error('삭제 실패:', err);
+      toast.error('삭제에 실패했습니다.');
+    }
+  };
+
+  // 드래그 앤 드롭 업로드
+  const handleDrop = async (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) await uploadFile(file);
+  };
+
+  // 파일 선택 업로드
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) await uploadFile(file);
+    e.target.value = '';
+  };
+
+  const uploadFile = async (file: File) => {
+    if (isDemo) {
+      toast.info('데모 모드에서는 파일 업로드가 지원되지 않습니다.');
+      return;
+    }
+    // 파일 형식 검증
+    if (!file.type.startsWith('video/')) {
+      toast.error('동영상 파일만 업로드할 수 있습니다.');
+      return;
+    }
+    // 파일 크기 검증 (2GB 제한)
+    if (file.size > 2 * 1024 * 1024 * 1024) {
+      toast.error('파일 크기는 2GB 이하여야 합니다.');
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('file', file);
+    setIsUploading(true);
+    try {
+      await apiClient.post('/api/v1/reconstruction/upload', formData);
+      toast.success('업로드 완료! 분석을 시작합니다.');
+      const data = await fetchRecords(debouncedKeyword);
+      if (data) schedulePolling(data);
+    } catch (err) {
+      console.error('업로드 실패:', err);
+      toast.error('파일 업로드에 실패했습니다.');
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  // Metrics
+  const totalCount = records.length;
+  const inProgressCount = records.filter(r => POLLING_STATUSES.includes(r.status)).length;
+  const completedCount = records.filter(r => r.status === 'COMPLETED').length;
+
+  const displayName =
+    user?.name?.trim() || (user ? generateNickname(user.userId || user.email || 'user') : '');
+
+  return (
+    <div
+      className="min-h-screen relative"
+      style={{
+        backgroundColor: '#f7f9f8',
+        fontFamily: '"Plus Jakarta Sans", "Pretendard", system-ui, sans-serif',
+      }}
+    >
+      {/* Subtle grid background */}
+      <div
+        aria-hidden
+        className="pointer-events-none fixed inset-0"
+        style={{
+          backgroundImage:
+            'linear-gradient(rgba(32,84,61,0.025) 1px, transparent 1px), linear-gradient(90deg, rgba(32,84,61,0.025) 1px, transparent 1px)',
+          backgroundSize: '48px 48px',
+          maskImage: 'linear-gradient(to bottom, black 0%, transparent 70%)',
+          WebkitMaskImage: 'linear-gradient(to bottom, black 0%, transparent 70%)',
+        }}
+      />
+
+      {/* ─── Header ─── */}
+      <header
+        className="sticky top-0 z-30 backdrop-blur-md"
+        style={{
+          backgroundColor: 'rgba(255,255,255,0.85)',
+          borderBottom: '1px solid #dae3dd',
+        }}
+      >
+        <div className="max-w-7xl mx-auto px-6 lg:px-10 h-16 flex items-center justify-between">
+          <button
+            onClick={() => navigate('/')}
+            className="flex items-center gap-2.5 transition-opacity hover:opacity-80"
+          >
+            <img src="/rs-mark.png" alt="ReScene" className="h-7 w-7" />
+            <span className="text-[16px] font-semibold tracking-tight text-[#20543d]">
+              ReScene
+            </span>
+            <span
+              className="text-[10px] font-mono px-2 py-0.5 rounded ml-1 hidden sm:inline-flex"
+              style={{ color: '#299283', backgroundColor: 'rgba(41,146,131,0.08)' }}
+            >
+              DASHBOARD
+            </span>
+          </button>
+          <div className="flex items-center gap-3">
+            {user && (
+              <div className="hidden sm:flex items-center gap-2.5 px-3 py-1.5 rounded-full" style={{ backgroundColor: '#eef2f0' }}>
+                <div
+                  className="w-7 h-7 rounded-full flex items-center justify-center text-[12px] font-semibold text-white"
+                  style={{ backgroundColor: '#299283' }}
+                >
+                  {displayName.charAt(0) || 'U'}
+                </div>
+                <span className="text-[13px] text-[#5a665e]">{displayName}</span>
+              </div>
+            )}
+            <button
+              onClick={logout}
+              className="flex items-center gap-1.5 px-3 py-2 text-[13px] text-[#5a665e] hover:text-[#20543d] hover:bg-[#eef2f0] rounded-md transition-colors"
+            >
+              <LogOut className="w-4 h-4" />
+              <span className="hidden sm:inline">로그아웃</span>
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main className="relative max-w-7xl mx-auto px-6 lg:px-10 py-10">
+
+        {/* ─── Top: Welcome + Metrics ─── */}
+        <div className="mb-10 grid grid-cols-1 lg:grid-cols-[1fr_auto] gap-8 items-end">
+          <div>
+            <div
+              className="text-[11px] tracking-widest uppercase mb-2 font-medium"
+              style={{ color: '#299283' }}
+            >
+              Dashboard
+            </div>
+            <h1 className="text-[28px] md:text-[32px] font-bold tracking-tight text-[#20543d] leading-tight">
+              {displayName ? `${displayName}님, 안녕하세요` : '안녕하세요'}
+            </h1>
+            <p className="mt-2 text-[14px] text-[#5a665e]">
+              새로운 영상을 업로드하거나 기존 분석 기록을 확인하세요.
+            </p>
+          </div>
+
+          {/* Metrics */}
+          <div className="grid grid-cols-3 gap-3">
+            {[
+              { label: '전체', value: totalCount, Icon: Activity, accent: false },
+              { label: '진행 중', value: inProgressCount, Icon: Clock, accent: true },
+              { label: '완료', value: completedCount, Icon: CheckCircle2, accent: false },
+            ].map(({ label, value, Icon, accent }) => (
+              <div
+                key={label}
+                className="rounded-lg px-4 py-3 bg-white min-w-[110px]"
+                style={{
+                  border: accent ? '1px solid rgba(41,146,131,0.25)' : '1px solid #dae3dd',
+                  boxShadow: accent ? '0 0 0 3px rgba(41,146,131,0.06)' : 'none',
+                }}
+              >
+                <div className="flex items-center justify-between mb-1.5">
+                  <span className="text-[11px] text-[#8a9590]">{label}</span>
+                  <Icon className="w-3.5 h-3.5" style={{ color: accent ? '#299283' : '#b8c4be' }} />
+                </div>
+                <div
+                  className="text-[22px] font-bold leading-none font-mono"
+                  style={{ color: accent ? '#299283' : '#20543d' }}
+                >
+                  {value}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* ─── Upload Section ─── */}
+        <section className="mb-10">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center gap-2.5">
+              <div className="w-1 h-4 rounded-full" style={{ backgroundColor: '#299283' }} />
+              <h2 className="text-[15px] font-semibold tracking-tight text-[#20543d]">
+                새 영상 업로드
+              </h2>
+            </div>
+            <span className="text-[11px] text-[#8a9590] font-mono">
+              MP4 · AVI · MOV · 최대 2GB
+            </span>
+          </div>
+
+          <div
+            className="bg-white rounded-xl overflow-hidden"
+            style={{ border: '1px solid #dae3dd' }}
+          >
+            <div
+              onDragOver={(e) => { e.preventDefault(); setIsDragging(true); }}
+              onDragLeave={() => setIsDragging(false)}
+              onDrop={handleDrop}
+              className="border-2 border-dashed m-2 rounded-lg p-10 text-center transition-all"
+              style={{
+                borderColor: isDragging ? '#299283' : '#dae3dd',
+                backgroundColor: isDragging ? '#e6f5f2' : 'transparent',
+              }}
+            >
+              {isUploading ? (
+                <div className="flex flex-col items-center gap-3 py-4">
+                  <div className="w-9 h-9 border-[3px] border-[#299283] border-t-transparent rounded-full animate-spin" />
+                  <p className="text-[14px] text-[#5a665e]">업로드 중...</p>
+                </div>
+              ) : (
+                <>
+                  <div
+                    className="inline-flex items-center justify-center w-14 h-14 rounded-full mb-4"
+                    style={{ backgroundColor: '#e6f5f2' }}
+                  >
+                    <Upload className="w-6 h-6" style={{ color: '#299283' }} />
+                  </div>
+                  <p className="text-[15px] font-medium text-[#20543d] mb-1">
+                    블랙박스 영상을 업로드하세요
+                  </p>
+                  <p className="text-[13px] text-[#8a9590] mb-5">
+                    파일을 드래그 앤 드롭하거나 아래 버튼을 클릭하세요
+                  </p>
+                  <label
+                    className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg text-[13px] font-medium text-white cursor-pointer transition-all hover:scale-[1.01]"
+                    style={{ backgroundColor: '#299283' }}
+                    onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = '#1a5f54')}
+                    onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = '#299283')}
+                  >
+                    파일 선택
+                    <input
+                      type="file"
+                      accept="video/*"
+                      onChange={handleFileSelect}
+                      className="hidden"
+                    />
+                  </label>
+                </>
+              )}
+            </div>
+          </div>
+        </section>
+
+        {/* ─── Analysis History ─── */}
+        <section className="mb-10">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center gap-2.5">
+              <div className="w-1 h-4 rounded-full" style={{ backgroundColor: '#299283' }} />
+              <h2 className="text-[15px] font-semibold tracking-tight text-[#20543d]">
+                나의 분석 기록
+              </h2>
+              {!isLoading && totalCount > 0 && (
+                <span
+                  className="text-[10px] font-mono px-1.5 py-0.5 rounded"
+                  style={{ color: '#5a665e', backgroundColor: '#eef2f0' }}
+                >
+                  {totalCount}건
+                </span>
+              )}
+            </div>
+            {!isDemo && inProgressCount > 0 && (
+              <div className="flex items-center gap-1.5 text-[11px]" style={{ color: '#299283' }}>
+                <div
+                  className="w-1.5 h-1.5 rounded-full"
+                  style={{
+                    backgroundColor: '#299283',
+                    animation: 'pulse 1.5s ease-in-out infinite',
+                  }}
+                />
+                <span className="font-mono">{inProgressCount}건 처리 중 · 자동 갱신</span>
+              </div>
+            )}
+          </div>
+
+          {isLoading ? (
+            <div
+              className="bg-white rounded-xl flex items-center justify-center h-48"
+              style={{ border: '1px solid #dae3dd' }}
+            >
+              <div className="flex flex-col items-center gap-3 text-[#8a9590]">
+                <div className="w-7 h-7 border-[3px] border-[#299283] border-t-transparent rounded-full animate-spin" />
+                <span className="text-[13px]">분석 기록을 불러오는 중...</span>
+              </div>
+            </div>
+          ) : (
+            <AnalysisHistory
+              records={records}
+              selectedJobId={selectedJobId}
+              onSelectJob={setSelectedJobId}
+              onRenameVideo={handleRenameVideo}
+              onDeleteRecord={handleDeleteRecord}
+              onSearchChange={setSearchKeyword}
+            />
+          )}
+        </section>
+
+        {/* ─── 3D Viewer ─── */}
+        {selectedRecord && selectedRecord.status === 'COMPLETED' && (
+          <section className="mb-10">
+            <div className="flex items-center gap-2.5 mb-3">
+              <div className="w-1 h-4 rounded-full" style={{ backgroundColor: '#299283' }} />
+              <h2 className="text-[15px] font-semibold tracking-tight text-[#20543d]">
+                3D 사고 복원
+              </h2>
+              <span className="text-[11px] font-mono text-[#8a9590]">
+                {selectedRecord.customTitle}
+              </span>
+            </div>
+            <Viewer3D
+              jobId={selectedRecord.jobId}
+              resultUrl={selectedRecord.resultUrl}
+              trajectoryUrl={selectedRecord.trajectoryUrl}
+            />
+          </section>
+        )}
+      </main>
+
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/app/LandingPage.tsx
+++ b/src/app/LandingPage.tsx
@@ -1,0 +1,629 @@
+import { useState, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router';
+
+/**
+ * ReScene 랜딩 페이지
+ * 브랜드 가이드 v2.0 — 9장 (이머시브 다크 모던) 기반
+ * Color: Deep Green (#20543d) + Teal (#299283)
+ */
+export function LandingPage() {
+  const navigate = useNavigate();
+  const [scrolled, setScrolled] = useState(false);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  // Scrolled nav state
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 30);
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  // Scroll-trigger fade-in
+  useEffect(() => {
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('rs-in');
+          }
+        });
+      },
+      { threshold: 0.15 },
+    );
+    document.querySelectorAll('.rs-reveal').forEach((el) => {
+      observerRef.current?.observe(el);
+    });
+    return () => observerRef.current?.disconnect();
+  }, []);
+
+  const goLogin = () => navigate('/login');
+
+  return (
+    <>
+      <style>{`
+        :root {
+          --green-950: #0a1e14;
+          --green-900: #0f2e1f;
+          --green-800: #153d2b;
+          --green-700: #1a4a34;
+          --green-500: #20543d;
+          --green-300: #4d8a6b;
+          --green-50:  #e6f0eb;
+          --teal-900:  #0d3d35;
+          --teal-700:  #1a5f54;
+          --teal-500:  #299283;
+          --teal-300:  #5cbfae;
+          --neutral-500: #5a665e;
+          --neutral-400: #8a9590;
+          --neutral-200: #dae3dd;
+          --neutral-100: #eef2f0;
+          --neutral-50:  #f7f9f8;
+        }
+        .rs-reveal {
+          opacity: 0;
+          transform: translateY(28px);
+          transition: opacity 0.7s ease-out, transform 0.7s ease-out;
+        }
+        .rs-reveal.rs-in {
+          opacity: 1;
+          transform: translateY(0);
+        }
+        .rs-stagger > * { transition-delay: 0s; }
+        .rs-stagger.rs-in > *:nth-child(1) { transition-delay: 0.05s; }
+        .rs-stagger.rs-in > *:nth-child(2) { transition-delay: 0.15s; }
+        .rs-stagger.rs-in > *:nth-child(3) { transition-delay: 0.25s; }
+        .rs-stagger.rs-in > *:nth-child(4) { transition-delay: 0.35s; }
+        .rs-stagger.rs-in > *:nth-child(5) { transition-delay: 0.45s; }
+        @keyframes rs-bounce {
+          0%, 100% { transform: translateY(0); opacity: 0.4; }
+          50% { transform: translateY(8px); opacity: 0.9; }
+        }
+        @keyframes rs-float {
+          0%, 100% { transform: translateY(0); }
+          50% { transform: translateY(-10px); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .rs-reveal { opacity: 1; transform: none; transition: none; }
+        }
+      `}</style>
+
+      <div
+        className="min-h-screen text-white font-sans"
+        style={{
+          backgroundColor: 'var(--green-950)',
+          fontFamily: '"Plus Jakarta Sans", "Pretendard", system-ui, sans-serif',
+        }}
+      >
+        {/* ─── Navigation ─── */}
+        <nav
+          className="fixed top-0 left-0 right-0 z-50 transition-all duration-300"
+          style={{
+            backgroundColor: scrolled ? 'rgba(10, 30, 20, 0.85)' : 'transparent',
+            backdropFilter: scrolled ? 'blur(12px)' : 'none',
+            WebkitBackdropFilter: scrolled ? 'blur(12px)' : 'none',
+            borderBottom: scrolled
+              ? '1px solid rgba(255,255,255,0.06)'
+              : '1px solid transparent',
+          }}
+        >
+          <div className="max-w-[1200px] mx-auto px-6 lg:px-10 h-16 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <img
+                src="/rs-mark.png"
+                alt="ReScene"
+                className="h-7 w-7"
+                style={{ filter: 'brightness(0) invert(1)' }}
+              />
+              <span className="text-[15px] font-semibold tracking-tight">ReScene</span>
+            </div>
+            <div className="hidden md:flex items-center gap-8 text-[14px]" style={{ color: 'rgba(255,255,255,0.7)' }}>
+              <a href="#problem" className="hover:text-white transition-colors">문제</a>
+              <a href="#solution" className="hover:text-white transition-colors">솔루션</a>
+              <a href="#pipeline" className="hover:text-white transition-colors">파이프라인</a>
+              <a href="#result" className="hover:text-white transition-colors">결과</a>
+            </div>
+            <button
+              onClick={goLogin}
+              className="px-5 py-2 rounded-lg text-[13px] font-medium text-white transition-all hover:scale-[1.02]"
+              style={{ backgroundColor: 'var(--teal-500)' }}
+              onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--teal-700)')}
+              onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'var(--teal-500)')}
+            >
+              시작하기
+            </button>
+          </div>
+        </nav>
+
+        {/* ─── Hero ─── */}
+        <section
+          className="relative flex items-center"
+          style={{
+            minHeight: '100vh',
+            background:
+              'linear-gradient(135deg, #0a1e14 0%, #0f2e1f 60%, #0d3d35 100%)',
+          }}
+        >
+          {/* Subtle grid overlay */}
+          <div
+            aria-hidden
+            className="absolute inset-0 pointer-events-none"
+            style={{
+              backgroundImage:
+                'linear-gradient(rgba(92,191,174,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(92,191,174,0.04) 1px, transparent 1px)',
+              backgroundSize: '64px 64px',
+              maskImage: 'radial-gradient(ellipse 70% 70% at 30% 50%, black 20%, transparent 75%)',
+              WebkitMaskImage: 'radial-gradient(ellipse 70% 70% at 30% 50%, black 20%, transparent 75%)',
+            }}
+          />
+
+          {/* Teal dot cluster (point-cloud motif) */}
+          <div aria-hidden className="absolute right-[10%] top-1/2 -translate-y-1/2 pointer-events-none">
+            <div className="relative w-[280px] h-[280px]">
+              {[
+                { x: 30, y: 20, s: 4, o: 0.9 },
+                { x: 80, y: 60, s: 3, o: 0.7 },
+                { x: 140, y: 30, s: 5, o: 1 },
+                { x: 200, y: 90, s: 3, o: 0.6 },
+                { x: 60, y: 130, s: 4, o: 0.8 },
+                { x: 170, y: 170, s: 6, o: 1 },
+                { x: 230, y: 140, s: 3, o: 0.5 },
+                { x: 110, y: 220, s: 4, o: 0.7 },
+                { x: 40, y: 200, s: 3, o: 0.6 },
+                { x: 220, y: 230, s: 5, o: 0.8 },
+              ].map((p, i) => (
+                <div
+                  key={i}
+                  className="absolute rounded-full"
+                  style={{
+                    left: p.x,
+                    top: p.y,
+                    width: p.s,
+                    height: p.s,
+                    backgroundColor: 'var(--teal-500)',
+                    opacity: p.o,
+                    boxShadow: `0 0 ${p.s * 3}px rgba(41,146,131,0.3)`,
+                    animation: `rs-float ${4 + (i % 3)}s ease-in-out ${i * 0.3}s infinite`,
+                  }}
+                />
+              ))}
+              {/* Connecting lines */}
+              <svg className="absolute inset-0 w-full h-full" style={{ opacity: 0.25 }}>
+                <line x1="32" y1="22" x2="142" y2="32" stroke="var(--teal-300)" strokeWidth="0.5" />
+                <line x1="142" y1="32" x2="172" y2="172" stroke="var(--teal-300)" strokeWidth="0.5" />
+                <line x1="62" y1="132" x2="172" y2="172" stroke="var(--teal-300)" strokeWidth="0.5" />
+                <line x1="172" y1="172" x2="222" y2="232" stroke="var(--teal-300)" strokeWidth="0.5" />
+              </svg>
+            </div>
+          </div>
+
+          <div className="relative max-w-[1200px] w-full mx-auto px-6 lg:px-10">
+            <div className="max-w-[680px]">
+              <div className="rs-reveal">
+                <div
+                  className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full mb-8"
+                  style={{
+                    backgroundColor: 'rgba(41,146,131,0.12)',
+                    border: '1px solid rgba(41,146,131,0.25)',
+                  }}
+                >
+                  <div
+                    className="w-1.5 h-1.5 rounded-full"
+                    style={{ backgroundColor: 'var(--teal-300)' }}
+                  />
+                  <span className="text-[12px] tracking-wide" style={{ color: 'var(--teal-300)' }}>
+                    3D Gaussian Splatting · 단안 영상 재구성
+                  </span>
+                </div>
+              </div>
+
+              <h1
+                className="rs-reveal text-[44px] md:text-[56px] font-bold leading-[1.1] tracking-tight mb-6"
+                style={{ fontFamily: '"DM Serif Display", Georgia, serif' }}
+              >
+                사고 장면을,{' '}
+                <span style={{ color: 'var(--teal-500)' }}>Re</span>Scene하다.
+              </h1>
+
+              <p
+                className="rs-reveal text-[18px] md:text-[20px] leading-relaxed mb-10 max-w-[560px]"
+                style={{ color: 'rgba(255,255,255,0.65)' }}
+              >
+                블랙박스 한 대의 영상만으로 사고 장면을 3D로 재구성합니다.
+                <br />
+                LiDAR 없이도 충돌 순간의 궤적과 속도를 객관적으로 분석합니다.
+              </p>
+
+              <div className="rs-reveal flex flex-col sm:flex-row gap-3">
+                <a
+                  href="#solution"
+                  className="px-7 py-3.5 rounded-lg text-[15px] font-medium text-white transition-all text-center"
+                  style={{
+                    backgroundColor: 'transparent',
+                    border: '1.5px solid rgba(255,255,255,0.2)',
+                  }}
+                  onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'rgba(255,255,255,0.05)')}
+                  onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
+                >
+                  자세히 보기
+                </a>
+              </div>
+            </div>
+          </div>
+
+          {/* Scroll hint */}
+          <div
+            aria-hidden
+            className="absolute bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center gap-1"
+            style={{ color: 'rgba(255,255,255,0.4)' }}
+          >
+            <span className="text-[11px] tracking-widest uppercase">scroll</span>
+            <div style={{ animation: 'rs-bounce 2s ease-in-out infinite' }}>
+              <svg viewBox="0 0 16 16" className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <path d="M4 6l4 4 4-4" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </div>
+          </div>
+        </section>
+
+        {/* ─── Problem (Light) ─── */}
+        <section id="problem" className="py-[120px]" style={{ backgroundColor: 'var(--neutral-50)' }}>
+          <div className="max-w-[1200px] mx-auto px-6 lg:px-10">
+            <div className="rs-reveal mb-16 max-w-[680px]">
+              <div className="text-[12px] tracking-widest uppercase mb-4" style={{ color: 'var(--teal-500)' }}>
+                Problem
+              </div>
+              <h2 className="text-[36px] md:text-[40px] font-bold leading-tight tracking-tight" style={{ color: 'var(--green-500)' }}>
+                기존 사고 분석의 한계
+              </h2>
+              <p className="mt-5 text-[16px] leading-relaxed" style={{ color: 'var(--neutral-500)' }}>
+                블랙박스는 일상화되었지만, 평면 영상만으로는 충돌 순간의 공간 정보를 파악할 수 없습니다.
+                전문 재구성 장비는 경찰·대형 보험사 전용이며 일반 피해자는 객관적 증거를 확보하기 어렵습니다.
+              </p>
+            </div>
+
+            <div className="rs-reveal rs-stagger grid grid-cols-1 md:grid-cols-3 gap-6">
+              {[
+                {
+                  stat: '80%+',
+                  label: '국내 블랙박스 보급률',
+                  desc: '단안 영상 데이터는 이미 대량으로 존재합니다.',
+                },
+                {
+                  stat: '20만+',
+                  label: '연간 교통사고 건수',
+                  desc: '경찰청 통계 기준, 매년 발생하는 사고 건수입니다.',
+                },
+                {
+                  stat: '2D',
+                  label: '현재 증거 한계',
+                  desc: '평면 영상만으로는 거리·속도·각도를 정확히 알 수 없습니다.',
+                },
+              ].map((item, i) => (
+                <div
+                  key={i}
+                  className="rs-reveal p-8 rounded-xl bg-white transition-all hover:-translate-y-1"
+                  style={{
+                    border: '1px solid var(--neutral-200)',
+                  }}
+                >
+                  <div
+                    className="text-[48px] font-bold leading-none mb-4"
+                    style={{ color: 'var(--teal-500)' }}
+                  >
+                    {item.stat}
+                  </div>
+                  <div className="text-[15px] font-semibold mb-2" style={{ color: 'var(--green-500)' }}>
+                    {item.label}
+                  </div>
+                  <div className="text-[14px] leading-relaxed" style={{ color: 'var(--neutral-500)' }}>
+                    {item.desc}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ─── Solution (Dark) ─── */}
+        <section id="solution" className="py-[120px]" style={{ backgroundColor: 'var(--green-900)' }}>
+          <div className="max-w-[1200px] mx-auto px-6 lg:px-10">
+            <div className="grid grid-cols-1 lg:grid-cols-[1.1fr_1fr] gap-16 items-center">
+              {/* 3D Mock visualization */}
+              <div
+                className="rs-reveal relative rounded-xl overflow-hidden"
+                style={{
+                  backgroundColor: 'var(--green-950)',
+                  border: '1px solid rgba(255,255,255,0.08)',
+                  aspectRatio: '4 / 3',
+                }}
+              >
+                {/* Header bar */}
+                <div
+                  className="flex items-center justify-between px-4 py-2.5"
+                  style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}
+                >
+                  <div className="flex items-center gap-3 text-[10px] font-mono" style={{ color: 'rgba(255,255,255,0.4)' }}>
+                    <span style={{ color: 'var(--teal-300)' }}>RC-2026-0041</span>
+                    <span
+                      className="px-1.5 py-0.5 rounded text-[9px]"
+                      style={{ color: 'var(--teal-300)', backgroundColor: 'rgba(41,146,131,0.15)' }}
+                    >
+                      복원 완료
+                    </span>
+                  </div>
+                  <span className="text-[10px] font-mono" style={{ color: 'rgba(255,255,255,0.3)' }}>847 / 847</span>
+                </div>
+
+                {/* SVG diagram */}
+                <div className="absolute left-0 right-0" style={{ top: '38px', bottom: '0' }}>
+                  <svg viewBox="0 0 480 360" className="w-full h-full" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    {/* Grid */}
+                    <g stroke="rgba(92,191,174,0.05)" strokeWidth="0.5">
+                      {[0,1,2,3,4,5,6,7,8].map(i => (
+                        <line key={`h${i}`} x1="28" y1={28 + i * 38} x2="452" y2={28 + i * 38} />
+                      ))}
+                      {[0,1,2,3,4,5,6,7,8].map(i => (
+                        <line key={`v${i}`} x1={28 + i * 53} y1="28" x2={28 + i * 53} y2="340" />
+                      ))}
+                    </g>
+
+                    {/* Trajectory A — teal */}
+                    <path d="M72 70 C130 88, 175 125, 242 182" stroke="rgba(41,146,131,0.15)" strokeWidth="18" strokeLinecap="round" fill="none" />
+                    <path d="M72 70 C130 88, 175 125, 242 182" stroke="var(--teal-300)" strokeOpacity="0.6" strokeWidth="1.2" strokeDasharray="6 4" fill="none" />
+
+                    {/* Trajectory B — green-light */}
+                    <path d="M408 290 C355 274, 310 238, 242 182" stroke="rgba(77,138,107,0.15)" strokeWidth="18" strokeLinecap="round" fill="none" />
+                    <path d="M408 290 C355 274, 310 238, 242 182" stroke="var(--green-300)" strokeOpacity="0.55" strokeWidth="1.2" strokeDasharray="6 4" fill="none" />
+
+                    {/* Impact */}
+                    <circle cx="242" cy="182" r="22" fill="var(--teal-500)" fillOpacity="0.06" />
+                    <circle cx="242" cy="182" r="9" fill="var(--teal-500)" fillOpacity="0.18" />
+                    <circle cx="242" cy="182" r="3" fill="var(--teal-500)" />
+
+                    {/* Angle */}
+                    <path d="M230 172 A15 15 0 0 1 254 192" stroke="rgba(255,255,255,0.2)" strokeWidth="0.6" fill="none" />
+                    <text x="256" y="172" fontSize="9" fill="var(--teal-300)" fontFamily="ui-monospace, monospace">47.2°</text>
+
+                    {/* A node */}
+                    <circle cx="72" cy="70" r="4" fill="var(--teal-500)" fillOpacity="0.15" stroke="var(--teal-300)" strokeOpacity="0.4" strokeWidth="0.8" />
+                    <circle cx="72" cy="70" r="1.5" fill="var(--teal-300)" />
+                    <text x="82" y="68" fontSize="10" fill="var(--teal-300)" fillOpacity="0.7" fontFamily="ui-monospace, monospace">차량 A</text>
+                    <text x="82" y="79" fontSize="8" fill="rgba(255,255,255,0.35)" fontFamily="ui-monospace, monospace">62.4 km/h</text>
+
+                    {/* B node */}
+                    <circle cx="408" cy="290" r="4" fill="var(--green-300)" fillOpacity="0.15" stroke="var(--green-300)" strokeOpacity="0.4" strokeWidth="0.8" />
+                    <circle cx="408" cy="290" r="1.5" fill="var(--green-300)" />
+                    <text x="372" y="313" fontSize="10" fill="var(--green-300)" fillOpacity="0.7" fontFamily="ui-monospace, monospace">차량 B</text>
+                    <text x="360" y="324" fontSize="8" fill="rgba(255,255,255,0.35)" fontFamily="ui-monospace, monospace">44.8 km/h</text>
+
+                    {/* Impact label */}
+                    <text x="200" y="206" fontSize="9" fill="rgba(255,255,255,0.5)" fontFamily="ui-monospace, monospace">충돌 지점</text>
+                    <text x="200" y="217" fontSize="8" fill="rgba(255,255,255,0.3)" fontFamily="ui-monospace, monospace">14:23:07.412</text>
+                  </svg>
+                </div>
+              </div>
+
+              {/* Text */}
+              <div className="rs-reveal">
+                <div className="text-[12px] tracking-widest uppercase mb-4" style={{ color: 'var(--teal-300)' }}>
+                  Solution
+                </div>
+                <h2 className="text-[36px] md:text-[40px] font-bold leading-tight tracking-tight text-white mb-6">
+                  단안 영상에서<br />
+                  <span style={{ color: 'var(--teal-500)' }}>3D 장면</span>을 복원합니다
+                </h2>
+                <p className="text-[16px] leading-relaxed mb-8" style={{ color: 'rgba(255,255,255,0.75)' }}>
+                  최신 단안 깊이 추정과 3D Gaussian Splatting을 결합한 End-to-End 파이프라인으로,
+                  블랙박스 영상 하나만 있으면 사고 장면을 다각도에서 분석할 수 있습니다.
+                </p>
+                <div className="space-y-4">
+                  {[
+                    { k: '차량별 궤적 자동 추출', v: '객체 추적과 깊이 정보 융합' },
+                    { k: '충돌 각도·속도 산출', v: '시간축 위치 미분으로 직접 계산' },
+                    { k: '자유 시점 렌더링', v: '브라우저에서 실시간 카메라 조작' },
+                  ].map((item, i) => (
+                    <div key={i} className="flex items-start gap-3">
+                      <div
+                        className="mt-1.5 w-1 h-1 rounded-full shrink-0"
+                        style={{ backgroundColor: 'var(--teal-500)' }}
+                      />
+                      <div>
+                        <div className="text-[15px] font-medium text-white">{item.k}</div>
+                        <div className="text-[13px] mt-0.5" style={{ color: 'rgba(255,255,255,0.5)' }}>{item.v}</div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ─── Pipeline (Darker) ─── */}
+        <section id="pipeline" className="py-[120px]" style={{ backgroundColor: 'var(--green-950)' }}>
+          <div className="max-w-[1200px] mx-auto px-6 lg:px-10">
+            <div className="rs-reveal mb-16 max-w-[680px]">
+              <div className="text-[12px] tracking-widest uppercase mb-4" style={{ color: 'var(--teal-300)' }}>
+                Pipeline
+              </div>
+              <h2 className="text-[36px] md:text-[40px] font-bold leading-tight tracking-tight text-white">
+                10단계 End-to-End 처리
+              </h2>
+              <p className="mt-5 text-[16px] leading-relaxed" style={{ color: 'rgba(255,255,255,0.7)' }}>
+                입력 영상부터 .splat 출력까지 모든 단계가 독립적으로 교체·개선 가능한 구조입니다.
+              </p>
+            </div>
+
+            <div className="rs-reveal rs-stagger grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
+              {[
+                { n: '01', t: '프레임 추출', d: 'FFmpeg, FPS 분리' },
+                { n: '02', t: '객체 분할 / 추적', d: 'YOLOv8 + ByteTrack' },
+                { n: '03', t: 'COLMAP SfM', d: '마스크 적용 포즈 추정' },
+                { n: '04', t: '단안 깊이 추정', d: 'Depth Anything V2' },
+                { n: '05', t: '스케일 정렬', d: 'COLMAP + 카메라 prior' },
+                { n: '06', t: '포인트 클라우드', d: '역투영 + 다중 프레임 병합' },
+                { n: '07', t: '아웃라이어 제거', d: 'Open3D SOR' },
+                { n: '08', t: '3D 궤적 추출', d: '객체별 시간축 위치' },
+                { n: '09', t: '3DGS 학습', d: '마스크 loss 제외' },
+                { n: '10', t: '.splat 변환', d: '웹 뷰어 출력' },
+              ].map((step, i) => (
+                <div
+                  key={i}
+                  className="rs-reveal p-5 rounded-xl transition-all hover:-translate-y-1"
+                  style={{
+                    backgroundColor: 'var(--green-800)',
+                    border: '1px solid rgba(255,255,255,0.06)',
+                    borderLeft: '3px solid var(--teal-500)',
+                  }}
+                >
+                  <div className="text-[11px] font-mono mb-2" style={{ color: 'var(--teal-300)' }}>
+                    STEP {step.n}
+                  </div>
+                  <div className="text-[15px] font-semibold text-white mb-1">{step.t}</div>
+                  <div className="text-[12px]" style={{ color: 'rgba(255,255,255,0.55)' }}>{step.d}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ─── Result Comparison (Light) ─── */}
+        <section id="result" className="py-[120px]" style={{ backgroundColor: 'var(--neutral-50)' }}>
+          <div className="max-w-[1200px] mx-auto px-6 lg:px-10">
+            <div className="rs-reveal mb-16 max-w-[680px]">
+              <div className="text-[12px] tracking-widest uppercase mb-4" style={{ color: 'var(--teal-500)' }}>
+                Result
+              </div>
+              <h2 className="text-[36px] md:text-[40px] font-bold leading-tight tracking-tight" style={{ color: 'var(--green-500)' }}>
+                기존 기술과의 차이
+              </h2>
+            </div>
+
+            <div className="rs-reveal grid grid-cols-1 md:grid-cols-3 gap-6">
+              {[
+                {
+                  title: 'Vanilla 3DGS',
+                  sub: '단안 + 마스크 없음',
+                  rows: [
+                    ['동적 객체 처리', '없음'],
+                    ['배경 재구성', '저하'],
+                    ['LiDAR 필요', '없음'],
+                  ],
+                  highlight: false,
+                },
+                {
+                  title: 'ReScene',
+                  sub: '본 파이프라인',
+                  rows: [
+                    ['동적 객체 처리', '마스크 분리'],
+                    ['배경 재구성', '고품질'],
+                    ['LiDAR 필요', '없음'],
+                  ],
+                  highlight: true,
+                },
+                {
+                  title: 'Street Gaussians',
+                  sub: 'LiDAR 기반',
+                  rows: [
+                    ['동적 객체 처리', '있음'],
+                    ['배경 재구성', '고품질'],
+                    ['LiDAR 필요', '필수'],
+                  ],
+                  highlight: false,
+                },
+              ].map((col, i) => (
+                <div
+                  key={i}
+                  className="rounded-xl p-6 transition-all hover:-translate-y-1"
+                  style={{
+                    backgroundColor: '#ffffff',
+                    border: col.highlight
+                      ? '2px solid var(--teal-500)'
+                      : '1px solid var(--neutral-200)',
+                    boxShadow: col.highlight ? '0 0 60px rgba(41, 146, 131, 0.12)' : 'none',
+                  }}
+                >
+                  <div className="flex items-center justify-between mb-1">
+                    <div className="text-[18px] font-bold" style={{ color: col.highlight ? 'var(--teal-500)' : 'var(--green-500)' }}>
+                      {col.title}
+                    </div>
+                    {col.highlight && (
+                      <span
+                        className="text-[10px] font-mono px-2 py-0.5 rounded"
+                        style={{ color: 'var(--teal-500)', backgroundColor: 'rgba(41,146,131,0.1)' }}
+                      >
+                        본 프로젝트
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-[12px] mb-5" style={{ color: 'var(--neutral-400)' }}>
+                    {col.sub}
+                  </div>
+                  <div className="space-y-3">
+                    {col.rows.map(([k, v], j) => (
+                      <div key={j} className="flex items-center justify-between py-2" style={{ borderBottom: '1px solid var(--neutral-100)' }}>
+                        <span className="text-[13px]" style={{ color: 'var(--neutral-500)' }}>{k}</span>
+                        <span className="text-[13px] font-medium" style={{ color: col.highlight ? 'var(--teal-500)' : 'var(--green-500)' }}>
+                          {v}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ─── CTA / Footer ─── */}
+        <section className="relative" style={{ backgroundColor: 'var(--green-950)' }}>
+          <div className="py-[120px] max-w-[1200px] mx-auto px-6 lg:px-10 text-center">
+            <div className="rs-reveal">
+              <img
+                src="/rs-mark.png"
+                alt="ReScene"
+                className="h-10 w-10 mx-auto mb-8 opacity-70"
+                style={{ filter: 'brightness(0) invert(1)' }}
+              />
+              <h2
+                className="text-[40px] md:text-[48px] font-bold leading-tight tracking-tight text-white mb-5"
+                style={{ fontFamily: '"DM Serif Display", Georgia, serif' }}
+              >
+                사고 장면을, <span style={{ color: 'var(--teal-500)' }}>다시</span> 만들다
+              </h2>
+              <p className="text-[17px] max-w-[520px] mx-auto" style={{ color: 'rgba(255,255,255,0.6)' }}>
+                블랙박스 단안 영상만으로 사고 장면을 3D Gaussian Splatting으로 재구성하는 End-to-End 파이프라인.
+              </p>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div
+            className="py-8 px-6 lg:px-10"
+            style={{ borderTop: '1px solid rgba(255,255,255,0.06)' }}
+          >
+            <div className="max-w-[1200px] mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
+              <div className="flex items-center gap-2">
+                <img
+                  src="/rs-mark.png"
+                  alt="ReScene"
+                  className="h-5 w-5 opacity-60"
+                  style={{ filter: 'brightness(0) invert(1)' }}
+                />
+                <span className="text-[13px]" style={{ color: 'rgba(255,255,255,0.5)' }}>
+                  ReScene
+                </span>
+                <span className="text-[11px] font-mono ml-2" style={{ color: 'rgba(255,255,255,0.3)' }}>
+                  v0.1.0
+                </span>
+              </div>
+              <span className="text-[12px]" style={{ color: 'rgba(255,255,255,0.35)' }}>
+                © 2026 ReScene · 졸업작품 프로젝트
+              </span>
+            </div>
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/src/app/LoginPreview3D.tsx
+++ b/src/app/LoginPreview3D.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+
+/**
+ * 로그인 화면 좌측 패널에서 hover 시 활성화되는 3D 미니 씬.
+ * - 차량 A·B(.glb) + 격자 바닥 + 궤적 라인 + 충돌 지점
+ * - 카메라 자동 orbit (사용자 인터랙션 없음)
+ * - pointer-events: none (로그인 폼 방해 금지)
+ */
+export default function LoginPreview3D() {
+  const mountRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+
+    let disposed = false;
+    let rafId: number | null = null;
+
+    const width = mount.clientWidth || 480;
+    const height = mount.clientHeight || 320;
+
+    // 씬·카메라·렌더러
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(40, width / height, 0.1, 100);
+    camera.position.set(7, 4.5, 7);
+    camera.lookAt(0, 0, 0);
+
+    const renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      alpha: true,
+    });
+    renderer.setSize(width, height);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setClearColor(0x080d16, 0);
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.toneMappingExposure = 1.1;
+    mount.appendChild(renderer.domElement);
+
+    // 조명 — 자연스러운 3-light setup
+    const ambient = new THREE.AmbientLight(0xc4d4e8, 0.45);
+    scene.add(ambient);
+    const hemi = new THREE.HemisphereLight(0xdce6f0, 0x1a2540, 0.35);
+    scene.add(hemi);
+    const dir = new THREE.DirectionalLight(0xffffff, 0.7);
+    dir.position.set(5, 12, 6);
+    scene.add(dir);
+    const fill = new THREE.DirectionalLight(0x8faabe, 0.2);
+    fill.position.set(-4, 3, -3);
+    scene.add(fill);
+
+    // 격자 바닥
+    const grid = new THREE.GridHelper(20, 24, 0x1e3550, 0x1e3550);
+    (grid.material as THREE.Material).opacity = 0.25;
+    (grid.material as THREE.Material).transparent = true;
+    scene.add(grid);
+
+    // 바닥면 — 미세한 반사
+    const floorGeo = new THREE.PlaneGeometry(20, 20);
+    const floorMat = new THREE.MeshStandardMaterial({
+      color: 0x0a1020,
+      roughness: 0.9,
+      metalness: 0.05,
+      transparent: true,
+      opacity: 0.4,
+    });
+    const floor = new THREE.Mesh(floorGeo, floorMat);
+    floor.rotation.x = -Math.PI / 2;
+    floor.position.y = -0.01;
+    scene.add(floor);
+
+    // 차량 컨테이너
+    const carA = new THREE.Group();
+    const carB = new THREE.Group();
+    carA.position.set(-2.2, 0, -1.5);
+    carA.rotation.y = Math.PI * 0.25;
+    carB.position.set(2.0, 0, 1.3);
+    carB.rotation.y = -Math.PI * 0.3;
+    scene.add(carA);
+    scene.add(carB);
+
+    // 차량 모델 로드 (실패해도 무시 — 격자만 표시되는 폴백)
+    const loader = new GLTFLoader();
+    loader.load(
+      '/car-a.glb',
+      (gltf) => {
+        if (disposed) return;
+        carA.add(gltf.scene);
+      },
+      undefined,
+      () => {},
+    );
+    loader.load(
+      '/car-b.glb',
+      (gltf) => {
+        if (disposed) return;
+        carB.add(gltf.scene);
+      },
+      undefined,
+      () => {},
+    );
+
+    // 궤적 라인 (차량 A → 충돌 지점)
+    const trajPts = [
+      new THREE.Vector3(-4.5, 0.05, -3.5),
+      new THREE.Vector3(-3.2, 0.05, -2.5),
+      new THREE.Vector3(-2.2, 0.05, -1.5),
+      new THREE.Vector3(0, 0.05, 0),
+      new THREE.Vector3(2.0, 0.05, 1.3),
+      new THREE.Vector3(3.5, 0.05, 2.8),
+    ];
+    const trajGeo = new THREE.BufferGeometry().setFromPoints(trajPts);
+    const trajMat = new THREE.LineBasicMaterial({
+      color: 0xdc8c64,
+      transparent: true,
+      opacity: 0.5,
+    });
+    const trajLine = new THREE.Line(trajGeo, trajMat);
+    scene.add(trajLine);
+
+    // 충돌 지점 마커
+    const impactGeo = new THREE.SphereGeometry(0.08, 16, 16);
+    const impactMat = new THREE.MeshBasicMaterial({ color: 0x60a5fa });
+    const impact = new THREE.Mesh(impactGeo, impactMat);
+    impact.position.set(0, 0.1, 0);
+    scene.add(impact);
+
+    // 카메라 자동 orbit
+    let angle = Math.PI * 0.25;
+    const radius = 7;
+    const heightY = 4.5;
+
+    const animate = () => {
+      if (disposed) return;
+      angle += 0.0018;
+      camera.position.x = Math.cos(angle) * radius;
+      camera.position.z = Math.sin(angle) * radius;
+      camera.position.y = heightY + Math.sin(angle * 0.5) * 0.2;
+      camera.lookAt(0, 0.2, 0);
+      renderer.render(scene, camera);
+      rafId = requestAnimationFrame(animate);
+    };
+    animate();
+
+    // 리사이즈 대응
+    const onResize = () => {
+      if (!mountRef.current) return;
+      const w = mountRef.current.clientWidth;
+      const h = mountRef.current.clientHeight;
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+      renderer.setSize(w, h);
+    };
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      disposed = true;
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      window.removeEventListener('resize', onResize);
+      renderer.dispose();
+      trajGeo.dispose();
+      trajMat.dispose();
+      impactGeo.dispose();
+      impactMat.dispose();
+      floorGeo.dispose();
+      floorMat.dispose();
+      if (mount.contains(renderer.domElement)) {
+        mount.removeChild(renderer.domElement);
+      }
+    };
+  }, []);
+
+  return (
+    <div
+      ref={mountRef}
+      className="absolute inset-0 w-full h-full"
+      style={{ pointerEvents: 'none' }}
+      aria-hidden
+    />
+  );
+}

--- a/src/app/LoginScreen.tsx
+++ b/src/app/LoginScreen.tsx
@@ -1,0 +1,568 @@
+import { useState, useEffect, lazy, Suspense } from 'react';
+import { useNavigate, useLocation } from 'react-router';
+import { useAuth } from '../../context/AuthContext';
+
+const LoginPreview3D = lazy(() => import('./LoginPreview3D'));
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080';
+
+/**
+ * 로그인 화면 — ReScene 브랜드 적용
+ * Deep Green (#20543d) + Teal (#299283) 2색 시스템
+ */
+export function LoginScreen() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { loginDemo } = useAuth();
+
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [loadingProvider, setLoadingProvider] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [preview3dActive, setPreview3dActive] = useState(false);
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const error = params.get('error');
+    if (error) {
+      setErrorMessage(decodeURIComponent(error));
+      navigate('/login', { replace: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleLogin = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!username || !password) return;
+    loginDemo();
+    navigate('/dashboard', { replace: true });
+  };
+
+  const handleSignUp = () => {
+    navigate('/signup');
+  };
+
+  const redirectToOAuth = (provider: 'google' | 'kakao' | 'naver') => {
+    setLoadingProvider(provider);
+    setErrorMessage(null);
+    setTimeout(() => {
+      window.location.href = `${API_BASE_URL}/oauth2/authorization/${provider}`;
+    }, 100);
+  };
+
+  const goLanding = () => navigate('/');
+
+  return (
+    <>
+    <style>{`
+      @keyframes fadeIn3d {
+        from { opacity: 0; }
+        to   { opacity: 1; }
+      }
+    `}</style>
+    <div
+      className="min-h-screen text-white flex flex-col relative overflow-hidden"
+      style={{
+        backgroundColor: '#0a1e14',
+        fontFamily: '"Plus Jakarta Sans", "Pretendard", system-ui, sans-serif',
+      }}
+    >
+
+      {/* Shared background grid */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage:
+            'linear-gradient(rgba(92,191,174,0.035) 1px, transparent 1px), linear-gradient(90deg, rgba(92,191,174,0.035) 1px, transparent 1px)',
+          backgroundSize: '48px 48px',
+          maskImage: 'radial-gradient(ellipse 80% 70% at 40% 50%, black 30%, transparent 80%)',
+          WebkitBackdropFilter: 'radial-gradient(ellipse 80% 70% at 40% 50%, black 30%, transparent 80%)',
+          WebkitMaskImage: 'radial-gradient(ellipse 80% 70% at 40% 50%, black 30%, transparent 80%)',
+        }}
+      />
+
+      {/* Top bar */}
+      <header className="relative flex items-center justify-between px-8 pt-5 pb-3">
+        <button
+          onClick={goLanding}
+          className="flex items-center gap-2 transition-opacity hover:opacity-80"
+        >
+          <img
+            src="/rs-mark.png"
+            alt="ReScene"
+            className="h-5 w-5"
+            style={{ filter: 'brightness(0) invert(1)' }}
+          />
+          <span className="text-[13px] font-semibold tracking-tight">ReScene</span>
+          <span className="text-[10px] font-mono ml-2" style={{ color: 'rgba(255,255,255,0.35)' }}>
+            v0.1.0
+          </span>
+        </button>
+        <span className="text-[10px] font-mono" style={{ color: 'rgba(255,255,255,0.35)' }}>
+          블랙박스 기반 사고 분석 시스템
+        </span>
+      </header>
+
+      <div className="relative flex-1 grid lg:grid-cols-[1.25fr_1fr] gap-0 min-h-0">
+
+        {/* ─── Left: Reconstruction preview ─── */}
+        <div className="hidden lg:flex flex-col pl-8 pr-6 pb-6 pt-2 min-h-0">
+
+          {/* Case header */}
+          <div className="flex items-center justify-between mb-2.5">
+            <div className="flex items-center gap-3">
+              <span className="text-[13px] font-mono tracking-tight" style={{ color: 'rgba(255,255,255,0.85)' }}>
+                RC-2026-0041
+              </span>
+              <span
+                className="text-[9px] font-mono px-1.5 py-0.5 rounded"
+                style={{ color: '#5cbfae', backgroundColor: 'rgba(41,146,131,0.12)' }}
+              >
+                복원 완료
+              </span>
+              <span className="text-[10px] font-mono" style={{ color: 'rgba(255,255,255,0.35)' }}>
+                2026-05-15
+              </span>
+            </div>
+            <div
+              className="flex items-center gap-4 text-[10px] font-mono"
+              style={{ color: 'rgba(255,255,255,0.45)' }}
+            >
+              <span>차량 2대</span>
+              <span>847 프레임</span>
+              <span>4.2초</span>
+              <span>자동</span>
+            </div>
+          </div>
+
+          {/* Reconstruction viewer */}
+          <div
+            className="relative rounded-lg overflow-hidden cursor-pointer flex-1 min-h-0"
+            style={{
+              backgroundColor: 'rgba(15,46,31,0.6)',
+              border: '1px solid rgba(255,255,255,0.06)',
+            }}
+            onMouseEnter={() => setPreview3dActive(true)}
+            onMouseLeave={() => setPreview3dActive(false)}
+          >
+            {/* Toolbar */}
+            <div
+              className="flex items-center justify-between px-3.5 py-2"
+              style={{ borderBottom: '1px solid rgba(255,255,255,0.05)' }}
+            >
+              <div className="flex items-center gap-1">
+                <span
+                  className="text-[10px] font-mono px-2 py-0.5 rounded"
+                  style={{
+                    color: '#5cbfae',
+                    backgroundColor: 'rgba(41,146,131,0.1)',
+                  }}
+                >
+                  궤적 2D
+                </span>
+                <span className="text-[10px] font-mono px-2 py-0.5" style={{ color: 'rgba(255,255,255,0.3)' }}>
+                  3D 뷰
+                </span>
+              </div>
+              <span className="text-[9px] font-mono" style={{ color: 'rgba(255,255,255,0.35)' }}>847 / 847</span>
+            </div>
+
+            {/* SVG diagram */}
+            <div
+              className="absolute left-0 right-0 bottom-0"
+              style={{
+                top: '30px',
+                opacity: preview3dActive ? 0 : 1,
+                transition: 'opacity 0.4s ease',
+              }}
+            >
+              <svg
+                viewBox="0 0 480 360"
+                className="w-full h-full"
+                preserveAspectRatio="xMidYMid meet"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                {/* Grid */}
+                <g stroke="rgba(92,191,174,0.05)" strokeWidth="0.5">
+                  {[0,1,2,3,4,5,6,7,8].map(i => (
+                    <line key={`h${i}`} x1="28" y1={28 + i * 38} x2="452" y2={28 + i * 38} />
+                  ))}
+                  {[0,1,2,3,4,5,6,7,8].map(i => (
+                    <line key={`v${i}`} x1={28 + i * 53} y1="28" x2={28 + i * 53} y2="340" />
+                  ))}
+                </g>
+
+                {/* Trajectory A — teal */}
+                <path d="M72 70 C130 88, 175 125, 242 182" stroke="rgba(41,146,131,0.12)" strokeWidth="14" strokeLinecap="round" fill="none" />
+                <path d="M72 70 C130 88, 175 125, 242 182" stroke="#5cbfae" strokeOpacity="0.45" strokeWidth="1" strokeDasharray="5 4" fill="none" />
+
+                <circle cx="100" cy="80" r="1.5" fill="#5cbfae" fillOpacity="0.3" />
+                <text x="104" y="78" fontSize="6.5" fill="rgba(255,255,255,0.3)" fontFamily="ui-monospace, monospace">f.210</text>
+                <circle cx="140" cy="100" r="1.5" fill="#5cbfae" fillOpacity="0.35" />
+                <text x="144" y="98" fontSize="6.5" fill="rgba(255,255,255,0.3)" fontFamily="ui-monospace, monospace">f.420</text>
+                <circle cx="182" cy="126" r="1.5" fill="#5cbfae" fillOpacity="0.4" />
+                <text x="186" y="124" fontSize="6.5" fill="rgba(255,255,255,0.3)" fontFamily="ui-monospace, monospace">f.630</text>
+                <circle cx="216" cy="156" r="1.5" fill="#5cbfae" fillOpacity="0.45" />
+
+                {/* Trajectory B — light green */}
+                <path d="M408 290 C355 274, 310 238, 242 182" stroke="rgba(77,138,107,0.1)" strokeWidth="14" strokeLinecap="round" fill="none" />
+                <path d="M408 290 C355 274, 310 238, 242 182" stroke="#4d8a6b" strokeOpacity="0.4" strokeWidth="1" strokeDasharray="5 4" fill="none" />
+
+                <circle cx="380" cy="282" r="1.5" fill="#4d8a6b" fillOpacity="0.3" />
+                <text x="362" y="278" fontSize="6.5" fill="rgba(255,255,255,0.3)" fontFamily="ui-monospace, monospace">f.195</text>
+                <circle cx="342" cy="260" r="1.5" fill="#4d8a6b" fillOpacity="0.35" />
+                <circle cx="300" cy="236" r="1.5" fill="#4d8a6b" fillOpacity="0.4" />
+                <circle cx="268" cy="210" r="1.5" fill="#4d8a6b" fillOpacity="0.45" />
+
+                {/* Impact zone */}
+                <circle cx="242" cy="182" r="18" fill="#299283" fillOpacity="0.04" />
+                <circle cx="242" cy="182" r="7" fill="#299283" fillOpacity="0.08" />
+                <circle cx="242" cy="182" r="2" fill="#299283" fillOpacity="0.85" />
+
+                {/* Angle arc */}
+                <path d="M230 172 A15 15 0 0 1 254 192" stroke="rgba(255,255,255,0.18)" strokeWidth="0.6" fill="none" />
+                <text x="256" y="172" fontSize="7" fill="#5cbfae" fillOpacity="0.7" fontFamily="ui-monospace, monospace">47.2°</text>
+
+                {/* Vehicle A node */}
+                <circle cx="72" cy="70" r="3" fill="#299283" fillOpacity="0.12" stroke="#5cbfae" strokeOpacity="0.3" strokeWidth="0.7" />
+                <circle cx="72" cy="70" r="1.2" fill="#5cbfae" fillOpacity="0.85" />
+                <text x="80" y="67" fontSize="9" fill="#5cbfae" fillOpacity="0.7" fontFamily="ui-monospace, monospace">차량 A</text>
+                <text x="80" y="78" fontSize="7.5" fill="rgba(255,255,255,0.35)" fontFamily="ui-monospace, monospace">62.4 km/h</text>
+
+                {/* Vehicle B node */}
+                <circle cx="408" cy="290" r="3" fill="#4d8a6b" fillOpacity="0.15" stroke="#4d8a6b" strokeOpacity="0.4" strokeWidth="0.7" />
+                <circle cx="408" cy="290" r="1.2" fill="#4d8a6b" fillOpacity="0.85" />
+                <text x="376" y="312" fontSize="9" fill="#4d8a6b" fillOpacity="0.7" fontFamily="ui-monospace, monospace">차량 B</text>
+                <text x="364" y="323" fontSize="7.5" fill="rgba(255,255,255,0.35)" fontFamily="ui-monospace, monospace">44.8 km/h</text>
+
+                {/* Impact label */}
+                <text x="200" y="206" fontSize="7.5" fill="rgba(255,255,255,0.45)" fontFamily="ui-monospace, monospace">충돌 지점</text>
+                <text x="200" y="216" fontSize="7" fill="rgba(255,255,255,0.3)" fontFamily="ui-monospace, monospace">14:23:07.412</text>
+
+                {/* Distance line */}
+                <line x1="72" y1="340" x2="408" y2="340" stroke="rgba(255,255,255,0.08)" strokeWidth="0.5" />
+                <line x1="72" y1="336" x2="72" y2="344" stroke="rgba(255,255,255,0.1)" strokeWidth="0.5" />
+                <line x1="242" y1="336" x2="242" y2="344" stroke="rgba(255,255,255,0.1)" strokeWidth="0.5" />
+                <line x1="408" y1="336" x2="408" y2="344" stroke="rgba(255,255,255,0.1)" strokeWidth="0.5" />
+                <text x="48" y="348" fontSize="6.5" fill="rgba(255,255,255,0.2)" fontFamily="ui-monospace, monospace">0m</text>
+                <text x="228" y="348" fontSize="6.5" fill="rgba(255,255,255,0.2)" fontFamily="ui-monospace, monospace">24m</text>
+                <text x="396" y="348" fontSize="6.5" fill="rgba(255,255,255,0.2)" fontFamily="ui-monospace, monospace">48m</text>
+
+                <text x="12" y="32" fontSize="6" fill="rgba(255,255,255,0.15)" fontFamily="ui-monospace, monospace">N</text>
+                <text x="12" y="338" fontSize="6" fill="rgba(255,255,255,0.15)" fontFamily="ui-monospace, monospace">S</text>
+              </svg>
+            </div>
+
+            {/* Frame progress */}
+            <div
+              className="absolute bottom-0 left-0 right-0 z-10"
+              style={{
+                opacity: preview3dActive ? 0 : 1,
+                transition: 'opacity 0.4s ease',
+              }}
+            >
+              <div className="h-[2px]" style={{ backgroundColor: 'rgba(255,255,255,0.03)' }}>
+                <div className="h-full" style={{ width: '100%', backgroundColor: 'rgba(41,146,131,0.4)' }} />
+              </div>
+            </div>
+
+            {/* 3D preview overlay */}
+            {preview3dActive && (
+              <div
+                className="absolute inset-0"
+                style={{ animation: 'fadeIn3d 0.4s ease' }}
+              >
+                <Suspense
+                  fallback={
+                    <div
+                      className="flex items-center justify-center h-full text-[11px]"
+                      style={{ color: 'rgba(255,255,255,0.4)' }}
+                    >
+                      로딩 중...
+                    </div>
+                  }
+                >
+                  <LoginPreview3D />
+                </Suspense>
+              </div>
+            )}
+          </div>
+
+          {/* Summary + legend */}
+          <div className="mt-2.5 flex items-start gap-4">
+            <div
+              className="flex-1 rounded-md px-3.5 py-2"
+              style={{
+                backgroundColor: 'rgba(15,46,31,0.4)',
+                border: '1px solid rgba(255,255,255,0.05)',
+              }}
+            >
+              <div className="grid grid-cols-4 gap-x-3 gap-y-1.5">
+                {[
+                  ['충돌 각도', '47.2°'],
+                  ['충돌 시각', '14:23:07'],
+                  ['분석 거리', '48.3m'],
+                  ['동기화', '완료'],
+                  ['차량 A', '62.4 km/h'],
+                  ['차량 B', '44.8 km/h'],
+                  ['포인트 클라우드', '1.2M'],
+                  ['정확도', '94.7%'],
+                ].map(([k, v]) => (
+                  <div key={k}>
+                    <div className="text-[9px] mb-0.5" style={{ color: 'rgba(255,255,255,0.4)' }}>{k}</div>
+                    <div className="text-[11px] font-mono" style={{ color: 'rgba(255,255,255,0.75)' }}>{v}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-1.5 pt-1 shrink-0">
+              <div className="flex items-center gap-1.5 text-[10px]">
+                <div className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: 'rgba(92,191,174,0.6)' }} />
+                <span style={{ color: 'rgba(255,255,255,0.45)' }}>차량 A</span>
+              </div>
+              <div className="flex items-center gap-1.5 text-[10px]">
+                <div className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: 'rgba(77,138,107,0.6)' }} />
+                <span style={{ color: 'rgba(255,255,255,0.45)' }}>차량 B</span>
+              </div>
+              <div className="flex items-center gap-1.5 text-[10px]">
+                <div className="w-1 h-1 rounded-full" style={{ backgroundColor: 'rgba(41,146,131,0.65)' }} />
+                <span style={{ color: 'rgba(255,255,255,0.45)' }}>충돌</span>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        {/* ─── Right: Login form ─── */}
+        <div className="flex items-center justify-center px-8 lg:pl-6 lg:pr-12">
+          <div className="w-full max-w-[340px]">
+
+            {/* Mobile brand */}
+            <button
+              onClick={goLanding}
+              className="lg:hidden flex items-center gap-2 mb-10 transition-opacity hover:opacity-80"
+            >
+              <img
+                src="/rs-mark.png"
+                alt="ReScene"
+                className="h-5 w-5"
+                style={{ filter: 'brightness(0) invert(1)' }}
+              />
+              <span className="text-[13px] font-semibold tracking-tight text-white">ReScene</span>
+            </button>
+
+            {/* System context */}
+            <div className="flex items-center gap-2 mb-5">
+              <div className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: 'rgba(92,191,174,0.7)' }} />
+              <span className="text-[10px] font-mono" style={{ color: 'rgba(255,255,255,0.45)' }}>
+                시스템 정상 운영 중
+              </span>
+            </div>
+
+            {/* Title */}
+            <div className="mb-6">
+              <h1 className="text-[20px] font-medium tracking-tight text-white">
+                로그인
+              </h1>
+              <p className="mt-1 text-[13px]" style={{ color: 'rgba(255,255,255,0.55)' }}>
+                계정에 로그인하여 분석을 시작하세요.
+              </p>
+            </div>
+
+            {/* Error */}
+            {errorMessage && (
+              <div
+                className="mb-5 px-3.5 py-2.5 rounded-md text-[13px]"
+                style={{
+                  backgroundColor: 'rgba(196,64,64,0.08)',
+                  border: '1px solid rgba(196,64,64,0.2)',
+                  color: 'rgba(255,180,180,0.95)',
+                }}
+              >
+                {errorMessage}
+              </div>
+            )}
+
+            {/* Form */}
+            <form onSubmit={handleLogin} className="space-y-3.5">
+              <div>
+                <label htmlFor="username" className="block text-[12px] mb-1.5" style={{ color: 'rgba(255,255,255,0.55)' }}>
+                  아이디
+                </label>
+                <input
+                  id="username"
+                  type="text"
+                  placeholder="사용자 이름 입력"
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  className="w-full px-3.5 py-2.5 rounded-lg text-[14px] text-white transition-colors focus:outline-none"
+                  style={{
+                    backgroundColor: 'rgba(21,61,43,0.5)',
+                    border: '1px solid rgba(255,255,255,0.08)',
+                  }}
+                  onFocus={(e) => {
+                    e.currentTarget.style.borderColor = '#299283';
+                    e.currentTarget.style.boxShadow = '0 0 0 3px rgba(41,146,131,0.15)';
+                  }}
+                  onBlur={(e) => {
+                    e.currentTarget.style.borderColor = 'rgba(255,255,255,0.08)';
+                    e.currentTarget.style.boxShadow = 'none';
+                  }}
+                />
+              </div>
+              <div>
+                <label htmlFor="password" className="block text-[12px] mb-1.5" style={{ color: 'rgba(255,255,255,0.55)' }}>
+                  비밀번호
+                </label>
+                <input
+                  id="password"
+                  type="password"
+                  placeholder="비밀번호 입력"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="w-full px-3.5 py-2.5 rounded-lg text-[14px] text-white transition-colors focus:outline-none"
+                  style={{
+                    backgroundColor: 'rgba(21,61,43,0.5)',
+                    border: '1px solid rgba(255,255,255,0.08)',
+                  }}
+                  onFocus={(e) => {
+                    e.currentTarget.style.borderColor = '#299283';
+                    e.currentTarget.style.boxShadow = '0 0 0 3px rgba(41,146,131,0.15)';
+                  }}
+                  onBlur={(e) => {
+                    e.currentTarget.style.borderColor = 'rgba(255,255,255,0.08)';
+                    e.currentTarget.style.boxShadow = 'none';
+                  }}
+                />
+              </div>
+
+              <div className="pt-1">
+                <button
+                  type="submit"
+                  disabled={!!loadingProvider}
+                  className="w-full py-2.5 rounded-lg text-white text-[14px] font-medium transition-all hover:scale-[1.01] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+                  style={{ backgroundColor: '#299283' }}
+                  onMouseEnter={(e) => { if (!loadingProvider) e.currentTarget.style.backgroundColor = '#1a5f54'; }}
+                  onMouseLeave={(e) => { if (!loadingProvider) e.currentTarget.style.backgroundColor = '#299283'; }}
+                >
+                  로그인
+                </button>
+              </div>
+
+              <button
+                type="button"
+                onClick={handleSignUp}
+                disabled={!!loadingProvider}
+                className="w-full py-2.5 rounded-lg bg-transparent text-[13px] transition-colors disabled:opacity-50"
+                style={{
+                  border: '1px solid rgba(255,255,255,0.1)',
+                  color: 'rgba(255,255,255,0.7)',
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor = 'rgba(255,255,255,0.04)';
+                  e.currentTarget.style.borderColor = 'rgba(255,255,255,0.15)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor = 'transparent';
+                  e.currentTarget.style.borderColor = 'rgba(255,255,255,0.1)';
+                }}
+              >
+                회원가입
+              </button>
+            </form>
+
+            {/* Divider */}
+            <div className="relative my-7">
+              <div className="absolute inset-0 flex items-center">
+                <div className="w-full" style={{ borderTop: '1px solid rgba(255,255,255,0.06)' }} />
+              </div>
+              <div className="relative flex justify-center">
+                <span
+                  className="px-3 text-[11px]"
+                  style={{ color: 'rgba(255,255,255,0.4)', backgroundColor: '#0a1e14' }}
+                >
+                  소셜 계정으로 계속
+                </span>
+              </div>
+            </div>
+
+            {/* Social login */}
+            <div className="space-y-2">
+              <button
+                type="button"
+                onClick={() => redirectToOAuth('google')}
+                disabled={!!loadingProvider}
+                className="w-full flex items-center justify-center gap-2.5 px-4 py-2.5 bg-white hover:bg-gray-50 text-gray-700 rounded-lg text-[13px] font-medium transition-colors disabled:opacity-50"
+              >
+                {loadingProvider === 'google' ? (
+                  <div className="w-4 h-4 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
+                ) : (
+                  <svg className="w-4 h-4" viewBox="0 0 24 24">
+                    <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
+                    <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+                    <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+                    <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+                  </svg>
+                )}
+                <span>{loadingProvider === 'google' ? '연결 중...' : 'Google'}</span>
+              </button>
+
+              <div className="grid grid-cols-2 gap-2">
+                <button
+                  type="button"
+                  onClick={() => redirectToOAuth('kakao')}
+                  disabled={!!loadingProvider}
+                  className="flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-[13px] font-medium transition-colors disabled:opacity-50"
+                  style={{ backgroundColor: '#FEE500' }}
+                >
+                  {loadingProvider === 'kakao' ? (
+                    <div className="w-4 h-4 border-2 border-yellow-800/50 border-t-transparent rounded-full animate-spin" />
+                  ) : (
+                    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="#3C1E1E">
+                      <path d="M12 3C6.477 3 2 6.477 2 10.8c0 2.713 1.617 5.1 4.073 6.558-.18.67-.651 2.424-.746 2.8-.116.458.168.453.353.33.146-.097 2.313-1.563 3.252-2.198.34.047.687.072 1.068.072 5.523 0 10-3.477 10-7.8C22 6.477 17.523 3 12 3z" />
+                    </svg>
+                  )}
+                  <span style={{ color: '#3C1E1E' }}>
+                    {loadingProvider === 'kakao' ? '...' : 'Kakao'}
+                  </span>
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => redirectToOAuth('naver')}
+                  disabled={!!loadingProvider}
+                  className="flex items-center justify-center gap-2 px-4 py-2.5 text-white rounded-lg text-[13px] font-medium transition-colors disabled:opacity-50"
+                  style={{ backgroundColor: '#03C75A' }}
+                >
+                  {loadingProvider === 'naver' ? (
+                    <div className="w-4 h-4 border-2 border-white/50 border-t-transparent rounded-full animate-spin" />
+                  ) : (
+                    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="white">
+                      <path d="M16.273 12.845 7.376 0H0v24h7.726V11.156L16.624 24H24V0h-7.727v12.845z" />
+                    </svg>
+                  )}
+                  <span>{loadingProvider === 'naver' ? '...' : 'Naver'}</span>
+                </button>
+              </div>
+            </div>
+
+            {/* Access context */}
+            <div
+              className="mt-7 flex items-center justify-between text-[10px]"
+              style={{ color: 'rgba(255,255,255,0.35)' }}
+            >
+              <span className="font-mono">최근 복원: 3건 대기 중</span>
+              <span className="font-mono">보안 접속</span>
+            </div>
+
+          </div>
+        </div>
+
+      </div>
+    </div>
+    </>
+  );
+}

--- a/src/app/Viewer3D.tsx
+++ b/src/app/Viewer3D.tsx
@@ -1,0 +1,946 @@
+import {
+  Component,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+
+// ─── 상수 ───────────────────────────────────────────────────────────────────
+
+const sampleTrajectoryA = [
+  [2.8, 0.05, 1.8],
+  [2.3, 0.05, 1.3],
+  [1.9, 0.05, 0.8],
+  [1.6, 0.05, 0.3],
+  [1.5, 0.05, -0.2],
+  [1.5, 0.05, -0.8],
+];
+
+const sampleTrajectoryB = [
+  [0.0, 0.05, 0.0],
+  [0.8, 0.05, -0.3],
+  [1.6, 0.05, -0.6],
+  [2.2, 0.05, -1.0],
+  [3.0, 0.05, -1.3],
+  [3.8, 0.05, -1.5],
+];
+
+// 데모용 기본 차량 모델 경로 (public 폴더)
+const DEMO_VEHICLE_URL_A = '/car-a.glb';
+const DEMO_VEHICLE_URL_B = '/car-b.glb';
+
+const defaultAccidentPoint = [1.5, 0.06, -0.8];
+const CAMERA_ROTATE_SPEED = 0.006;
+const CAMERA_PAN_MULTIPLIER = 0.0065;
+const CAMERA_DOLLY_IN = 0.84;
+const CAMERA_DOLLY_OUT = 1.16;
+const CAMERA_MIN_DISTANCE = 2.8;
+const CAMERA_MAX_DISTANCE = 40;
+const CAMERA_MIN_PHI = 0.35;
+const CAMERA_MAX_PHI = Math.PI / 2 - 0.12;
+
+// ─── 타입 ────────────────────────────────────────────────────────────────────
+
+interface Viewer3DProps {
+  jobId: string;
+  resultUrl?: string;      // Gaussian Splat (.splat) URL
+  trajectoryUrl?: string;  // 차량 A 궤적 JSON URL
+}
+
+interface OrbitState {
+  theta: number;
+  phi: number;
+  distance: number;
+  target: [number, number, number];
+}
+
+interface Point3D { x: number; y: number; z: number }
+interface NormalizedPoint extends Point3D { t: number | null; index: number; raw: unknown }
+interface SampleResult { position: [number, number, number]; next: [number, number, number] }
+
+// ─── 에러 바운더리 ────────────────────────────────────────────────────────────
+
+interface ErrorBoundaryState { hasError: boolean; message: string }
+
+class ViewerErrorBoundary extends Component<{ children: React.ReactNode }, ErrorBoundaryState> {
+  constructor(props: { children: React.ReactNode }) {
+    super(props);
+    this.state = { hasError: false, message: '' };
+  }
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true, message: error?.message || '알 수 없는 렌더링 오류' };
+  }
+  componentDidCatch() {}
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="rounded-2xl border border-red-200 bg-red-50 p-6 text-red-700">
+          <div className="font-bold">뷰어 렌더링 오류</div>
+          <div className="mt-2 text-sm">{this.state.message}</div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+// ─── 유틸 함수 ───────────────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setVectorLike(target: any, x: number, y: number, z: number): boolean {
+  if (!target) return false;
+  if (typeof target.set === 'function') { target.set(x, y, z); return true; }
+  if (Array.isArray(target)) { target[0] = x; target[1] = y; target[2] = z; return true; }
+  if (typeof target === 'object') {
+    let changed = false;
+    if ('x' in target) { target.x = x; changed = true; }
+    if ('y' in target) { target.y = y; changed = true; }
+    if ('z' in target) { target.z = z; changed = true; }
+    return changed;
+  }
+  return false;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function safeSetGsplatCameraPosition(camera: any, x: number, y: number, z: number) {
+  if (!camera) return false;
+  return (
+    setVectorLike(camera.position, x, y, z) ||
+    setVectorLike(camera._position, x, y, z) ||
+    setVectorLike(camera.translation, x, y, z)
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function safeReadGsplatPosition(camera: any): Point3D | null {
+  const candidate = camera && (camera.position || camera._position || camera.translation);
+  if (!candidate) return null;
+  if (Array.isArray(candidate) && candidate.length >= 3) {
+    return { x: Number(candidate[0]) || 0, y: Number(candidate[1]) || 0, z: Number(candidate[2]) || 0 };
+  }
+  if (typeof candidate.x === 'number' && typeof candidate.y === 'number' && typeof candidate.z === 'number') {
+    return { x: candidate.x, y: candidate.y, z: candidate.z };
+  }
+  return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function safeSetGsplatTarget(controls: any, x: number, y: number, z: number) {
+  if (!controls?.target || typeof controls.target.set !== 'function') return false;
+  controls.target.set(x, y, z);
+  return true;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function copyGsplatCameraToThreeCamera(gsCamera: any, threeCamera: any) {
+  if (!gsCamera || !threeCamera) return;
+  const gsPosition = safeReadGsplatPosition(gsCamera);
+  const gsQuaternion = gsCamera.quaternion || gsCamera._quaternion;
+  if (gsPosition) threeCamera.position.set(gsPosition.x, gsPosition.y, gsPosition.z);
+  if (gsQuaternion && typeof gsQuaternion.x === 'number') {
+    threeCamera.quaternion.set(gsQuaternion.x, gsQuaternion.y, gsQuaternion.z, gsQuaternion.w);
+  }
+  const maybeFov = gsCamera.fov ?? gsCamera._fov ?? gsCamera._data?._fov;
+  const maybeNear = gsCamera.near ?? gsCamera._near ?? gsCamera._data?._near;
+  const maybeFar = gsCamera.far ?? gsCamera._far ?? gsCamera._data?._far;
+  if (typeof maybeFov === 'number') threeCamera.fov = maybeFov;
+  if (typeof maybeNear === 'number') threeCamera.near = maybeNear;
+  if (typeof maybeFar === 'number') threeCamera.far = maybeFar;
+  threeCamera.updateProjectionMatrix();
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getPointComponents(point: any): { x: number; y: number; z: number; t: number | null } {
+  if (Array.isArray(point)) {
+    return {
+      x: Number(point[0] || 0), y: Number(point[1] || 0), z: Number(point[2] || 0),
+      t: point.length > 3 ? Number(point[3]) || 0 : null,
+    };
+  }
+  if (point && typeof point === 'object') {
+    const tValue = point.t ?? point.time ?? point.timestamp;
+    return {
+      x: Number(point.x ?? point.X ?? 0) || 0,
+      y: Number(point.y ?? point.Y ?? point.height ?? 0) || 0,
+      z: Number(point.z ?? point.Z ?? 0) || 0,
+      t: tValue != null ? Number(tValue) || 0 : null,
+    };
+  }
+  return { x: 0, y: 0, z: 0, t: null };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function normalizeTrajectoryPoints(points: any[]): NormalizedPoint[] {
+  const raw = Array.isArray(points) ? points : [];
+  return raw.map((point, index) => {
+    const parsed = getPointComponents(point);
+    return { x: parsed.x, y: parsed.y, z: parsed.z, t: parsed.t, index, raw: point };
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function trajectoryHasTimestamps(points: any[]) {
+  const normalized = normalizeTrajectoryPoints(points);
+  return normalized.length > 1 && normalized.every((p) => p.t != null);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getTrajectoryCenter(pointsA: any[], pointsB: any[]): [number, number, number] {
+  const merged = [...(Array.isArray(pointsA) ? pointsA : []), ...(Array.isArray(pointsB) ? pointsB : [])];
+  if (merged.length === 0) return [0, 0.22, 0];
+  let sumX = 0, sumZ = 0;
+  merged.forEach((p) => { const c = getPointComponents(p); sumX += c.x; sumZ += c.z; });
+  return [sumX / merged.length, 0.22, sumZ / merged.length];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getFramedCameraPosition(center: [number, number, number], pointsA: any[], pointsB: any[]): [number, number, number] {
+  const merged = [...(Array.isArray(pointsA) ? pointsA : []), ...(Array.isArray(pointsB) ? pointsB : [])];
+  if (merged.length === 0) return [0, 3.2, 6.8];
+  let minX = Infinity, maxX = -Infinity, minZ = Infinity, maxZ = -Infinity;
+  merged.forEach((p) => { const c = getPointComponents(p); minX = Math.min(minX, c.x); maxX = Math.max(maxX, c.x); minZ = Math.min(minZ, c.z); maxZ = Math.max(maxZ, c.z); });
+  const spanX = Math.max(1.6, maxX - minX);
+  const spanZ = Math.max(1.6, maxZ - minZ);
+  const depth = Math.max(spanX, spanZ);
+  return [center[0], 3.2 + depth * 0.55, center[2] + 5.4 + depth * 0.9];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getAccidentPoint(pointsA: any[], pointsB: any[]): [number, number, number] {
+  const a = Array.isArray(pointsA) ? pointsA : [];
+  const b = Array.isArray(pointsB) ? pointsB : [];
+  if (a.length === 0 && b.length === 0) return [...defaultAccidentPoint] as [number, number, number];
+  if (a.length === 0) { const lb = getPointComponents(b[b.length - 1]); return [lb.x, lb.y + 0.01, lb.z]; }
+  if (b.length === 0) { const la = getPointComponents(a[a.length - 1]); return [la.x, la.y + 0.01, la.z]; }
+  let bestA = getPointComponents(a[0]), bestB = getPointComponents(b[0]), bestDist = Infinity;
+  a.forEach((pa_) => {
+    const pa = getPointComponents(pa_);
+    b.forEach((pb_) => {
+      const pb = getPointComponents(pb_);
+      const d = (pa.x - pb.x) ** 2 + (pa.y - pb.y) ** 2 + (pa.z - pb.z) ** 2;
+      if (d < bestDist) { bestDist = d; bestA = pa; bestB = pb; }
+    });
+  });
+  return [(bestA.x + bestB.x) / 2, (bestA.y + bestB.y) / 2 + 0.01, (bestA.z + bestB.z) / 2];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function findClosestPointPair(pointsA: any[], pointsB: any[]) {
+  const a = normalizeTrajectoryPoints(pointsA);
+  const b = normalizeTrajectoryPoints(pointsB);
+  if (a.length === 0 || b.length === 0) return null;
+  let best = { indexA: 0, indexB: 0, distanceSq: Infinity };
+  a.forEach((pa, indexA) => {
+    b.forEach((pb, indexB) => {
+      const d = (pa.x - pb.x) ** 2 + (pa.y - pb.y) ** 2 + (pa.z - pb.z) ** 2;
+      if (d < best.distanceSq) best = { indexA, indexB, distanceSq: d };
+    });
+  });
+  return best;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function computePointSpeedKmh(points: any[], index: number): number | null {
+  const normalized = normalizeTrajectoryPoints(points);
+  if (normalized.length < 2 || !normalized.every((p) => p.t != null)) return null;
+  const cur = Math.max(0, Math.min(normalized.length - 1, index));
+  const start = cur === 0 ? normalized[0] : normalized[cur - 1];
+  const end = cur === normalized.length - 1 ? normalized[normalized.length - 1] : normalized[Math.min(cur + 1, normalized.length - 1)];
+  const dt = Math.max(1e-6, (end.t as number) - (start.t as number));
+  const ms = Math.sqrt((end.x - start.x) ** 2 + (end.y - start.y) ** 2 + (end.z - start.z) ** 2) / dt;
+  return ms * 3.6;
+}
+
+function formatSpeedKmh(speed: number | null | undefined) {
+  if (speed == null || !Number.isFinite(speed)) return '시간 정보 없음';
+  return `${speed.toFixed(1)} km/h`;
+}
+
+function computeOrbitStateFromFrame(target: [number, number, number], framedPos: [number, number, number]): OrbitState {
+  const dx = framedPos[0] - target[0], dy = framedPos[1] - target[1], dz = framedPos[2] - target[2];
+  const distance = Math.min(CAMERA_MAX_DISTANCE, Math.max(CAMERA_MIN_DISTANCE, Math.sqrt(dx * dx + dy * dy + dz * dz)));
+  return {
+    theta: Math.atan2(dz, dx),
+    phi: Math.min(CAMERA_MAX_PHI, Math.max(CAMERA_MIN_PHI, Math.acos(dy / distance))),
+    distance,
+    target: [target[0], target[1], target[2]],
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function applyOrbitStateToCamera(state: OrbitState, camera: any, controls: any) {
+  const { theta, phi, distance, target } = state;
+  safeSetGsplatCameraPosition(camera, target[0] + distance * Math.sin(phi) * Math.cos(theta), target[1] + distance * Math.cos(phi), target[2] + distance * Math.sin(phi) * Math.sin(theta));
+  safeSetGsplatTarget(controls, target[0], target[1], target[2]);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function panCameraByScreenDelta(THREE: any, orbitState: OrbitState, camera: any, controls: any, deltaX: number, deltaY: number) {
+  const position = safeReadGsplatPosition(camera);
+  if (!position) return;
+  const pos = new THREE.Vector3(position.x, position.y, position.z);
+  const tgt = new THREE.Vector3(...orbitState.target);
+  const forward = new THREE.Vector3().subVectors(tgt, pos).normalize();
+  const worldUp = new THREE.Vector3(0, 1, 0);
+  const right = new THREE.Vector3().crossVectors(forward, worldUp).normalize();
+  const up = new THREE.Vector3().crossVectors(right, forward).normalize();
+  const scale = orbitState.distance * CAMERA_PAN_MULTIPLIER;
+  const movement = new THREE.Vector3().addScaledVector(right, -deltaX * scale).addScaledVector(up, deltaY * scale);
+  orbitState.target = [orbitState.target[0] + movement.x, orbitState.target[1] + movement.y, orbitState.target[2] + movement.z];
+  applyOrbitStateToCamera(orbitState, camera, controls);
+}
+
+function dollyCameraTowardTarget(orbitState: OrbitState, camera: unknown, controls: unknown, deltaY: number) {
+  orbitState.distance = Math.min(CAMERA_MAX_DISTANCE, Math.max(CAMERA_MIN_DISTANCE, orbitState.distance * (deltaY > 0 ? CAMERA_DOLLY_OUT : CAMERA_DOLLY_IN)));
+  applyOrbitStateToCamera(orbitState, camera, controls);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getTrajectoryDuration(points: any[]) {
+  const normalized = normalizeTrajectoryPoints(points);
+  if (normalized.length <= 1) return normalized.length;
+  if (normalized.every((p) => p.t != null)) {
+    const duration = (normalized[normalized.length - 1].t as number) - (normalized[0].t as number);
+    return duration > 0 ? duration : normalized.length - 1;
+  }
+  return normalized.length - 1;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function samplePath(points: any[], progressOrTime: number): SampleResult {
+  const normalized = normalizeTrajectoryPoints(points);
+  if (normalized.length === 0) return { position: [0, 0, 0], next: [0, 0, -1] };
+  if (normalized.length === 1) {
+    const p = normalized[0];
+    return { position: [p.x, p.y, p.z], next: [p.x, p.y, p.z - 1] };
+  }
+  const hasTs = normalized.every((p) => p.t != null);
+  if (hasTs) {
+    const startTime = normalized[0].t as number;
+    const endTime = normalized[normalized.length - 1].t as number;
+    const targetTime = Math.max(startTime, Math.min(endTime, startTime + progressOrTime));
+    let idx = 0;
+    while (idx < normalized.length - 2 && (normalized[idx + 1].t as number) < targetTime) idx++;
+    const cur = normalized[idx], nxt = normalized[Math.min(idx + 1, normalized.length - 1)];
+    const dt = Math.max(1e-6, (nxt.t as number) - (cur.t as number));
+    const localT = Math.max(0, Math.min(1, (targetTime - (cur.t as number)) / dt));
+    return { position: [cur.x + (nxt.x - cur.x) * localT, cur.y + (nxt.y - cur.y) * localT, cur.z + (nxt.z - cur.z) * localT], next: [nxt.x, nxt.y, nxt.z] };
+  }
+  const clamped = Math.max(0, Math.min(0.999999, progressOrTime));
+  const scaled = clamped * (normalized.length - 1);
+  const idx = Math.floor(scaled);
+  const localT = scaled - idx;
+  const cur = normalized[idx], nxt = normalized[Math.min(idx + 1, normalized.length - 1)];
+  return { position: [cur.x + (nxt.x - cur.x) * localT, cur.y + (nxt.y - cur.y) * localT, cur.z + (nxt.z - cur.z) * localT], next: [nxt.x, nxt.y, nxt.z] };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function disposeThreeObject(root: any) {
+  if (!root?.traverse) return;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  root.traverse((obj: any) => {
+    obj.geometry?.dispose?.();
+    if (Array.isArray(obj.material)) obj.material.forEach((m: any) => m?.dispose?.());
+    else obj.material?.dispose?.();
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function createFallbackCar(THREE: any, color: number) {
+  const group = new THREE.Group();
+  const body = new THREE.Mesh(new THREE.BoxGeometry(1.7, 0.45, 0.9), new THREE.MeshStandardMaterial({ color }));
+  body.position.y = 0.3;
+  group.add(body);
+  const cabin = new THREE.Mesh(new THREE.BoxGeometry(0.9, 0.35, 0.8), new THREE.MeshStandardMaterial({ color }));
+  cabin.position.set(0, 0.6, 0);
+  group.add(cabin);
+  [[-0.55, 0.1, 0.48], [0.55, 0.1, 0.48], [-0.55, 0.1, -0.48], [0.55, 0.1, -0.48]].forEach(([x, y, z]) => {
+    const wheel = new THREE.Mesh(new THREE.CylinderGeometry(0.18, 0.18, 0.18, 20), new THREE.MeshStandardMaterial({ color: 0x111827 }));
+    wheel.rotation.z = Math.PI / 2;
+    wheel.position.set(x, y, z);
+    group.add(wheel);
+  });
+  return group;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function normalizeVehicleModel(THREE: any, model: any) {
+  const wrapper = new THREE.Group();
+  wrapper.add(model);
+  const box = new THREE.Box3().setFromObject(model);
+  const size = new THREE.Vector3();
+  const center = new THREE.Vector3();
+  box.getSize(size);
+  box.getCenter(center);
+  const maxDim = Math.max(size.x || 0, size.y || 0, size.z || 0);
+  const scale = maxDim > 0 ? 1.9 / maxDim : 1;
+  model.position.sub(center);
+  model.scale.multiplyScalar(scale);
+  const scaledBox = new THREE.Box3().setFromObject(model);
+  const minY = scaledBox.min.y;
+  if (Number.isFinite(minY)) model.position.y -= minY;
+  return wrapper;
+}
+
+async function safeFetchJson(url: string) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`fetch "${url}" → ${res.status}`);
+  return res.json();
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function loadTrajectoryJson(url: string | undefined, fallbackData: any[]) {
+  if (!url) return { points: fallbackData, source: 'sample-no-url' };
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: any = await safeFetchJson(url);
+    if (Array.isArray(data)) return { points: data, source: 'remote-json' };
+    if (Array.isArray(data?.points)) return { points: data.points, source: 'remote-json.points' };
+    if (Array.isArray(data?.trajectory)) return { points: data.trajectory, source: 'remote-json.trajectory' };
+    if (Array.isArray(data?.positions)) return { points: data.positions, source: 'remote-json.positions' };
+    return { points: fallbackData, source: 'sample-invalid-shape' };
+  } catch {
+    return { points: fallbackData, source: 'sample-fetch-error' };
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function loadSplatScene({ SPLAT, url, scene }: { SPLAT: any; url: string | undefined; scene: any }) {
+  if (!url) return { ok: false };
+  try {
+    await SPLAT.Loader.LoadAsync(url, scene, () => {});
+    return { ok: true };
+  } catch {
+    return { ok: false };
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function loadVehicleModel({ THREE, GLTFLoader, url, fallbackColor }: { THREE: any; GLTFLoader: any; url: string | undefined; fallbackColor: number }) {
+  if (!url) return { model: createFallbackCar(THREE, fallbackColor), source: 'fallback-no-url' };
+  try {
+    const loader = new GLTFLoader();
+    const res = await fetch(url);
+    if (!res.ok) throw new Error('model fetch failed');
+    const arrayBuffer = await res.arrayBuffer();
+    const basePath = url.startsWith('blob:') ? '' : url.slice(0, url.lastIndexOf('/') + 1);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const gltf = await new Promise<any>((resolve, reject) => loader.parse(arrayBuffer, basePath, resolve, reject));
+    const rawModel = gltf?.scene?.clone ? gltf.scene.clone(true) : null;
+    if (!rawModel) return { model: createFallbackCar(THREE, fallbackColor), source: 'fallback-empty-scene' };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rawModel.traverse((obj: any) => { if (obj.isMesh) { obj.castShadow = true; obj.receiveShadow = true; } });
+    return { model: normalizeVehicleModel(THREE, rawModel), source: 'remote-model' };
+  } catch {
+    return { model: createFallbackCar(THREE, fallbackColor), source: 'fallback-load-error' };
+  }
+}
+
+// ─── HTML 폴백 (Three.js 로드 전 표시) ───────────────────────────────────────
+
+function HtmlFallbackPreview({ showVehicleA, showVehicleB, showAccidentPoint, showTrajectoryLines }: {
+  showVehicleA: boolean; showVehicleB: boolean; showAccidentPoint: boolean; showTrajectoryLines: boolean;
+}) {
+  return (
+    <div className="absolute inset-0 z-30 overflow-hidden rounded-2xl bg-[radial-gradient(circle_at_top,_#1e293b,_#020617)]">
+      <div className="absolute inset-0 opacity-35" style={{ backgroundImage: 'linear-gradient(rgba(148,163,184,0.24) 1px, transparent 1px), linear-gradient(90deg, rgba(148,163,184,0.24) 1px, transparent 1px)', backgroundSize: '32px 32px' }} />
+      {showTrajectoryLines && (
+        <svg className="absolute inset-0 h-full w-full" viewBox="0 0 1000 760" preserveAspectRatio="none">
+          <polyline points="250,430 340,420 430,405 520,385 615,365 710,345" fill="none" stroke="#60a5fa" strokeWidth="5" />
+          <polyline points="720,280 650,320 590,355 545,390 515,425 500,470" fill="none" stroke="#f87171" strokeWidth="5" />
+        </svg>
+      )}
+      {showVehicleA && <div className="absolute left-[46%] top-[50%] h-10 w-20 -translate-x-1/2 -translate-y-1/2 rounded-xl bg-[#e6f5f2]0/85 shadow-xl" />}
+      {showVehicleB && <div className="absolute left-[58%] top-[56%] h-10 w-20 -translate-x-1/2 -translate-y-1/2 rounded-xl bg-red-500/85 shadow-xl" />}
+      {showAccidentPoint && <div className="absolute left-[51.5%] top-[61%] h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-amber-400" />}
+    </div>
+  );
+}
+
+// ─── ViewerPane (Three.js + gsplat 렌더러) ────────────────────────────────────
+
+interface ViewerPaneProps {
+  splatUrl?: string;
+  trajectoryUrlA?: string;
+  trajectoryUrlB?: string;
+  showVehicleA: boolean;
+  showVehicleB: boolean;
+  showAccidentPoint: boolean;
+  showTrajectoryLines: boolean;
+  autoPlay: boolean;
+  playbackSpeed: number;
+  playbackLoop: boolean;
+  onStatusChange: (s: { phase: string; message: string }) => void;
+  onLoadedMeta: (m: Record<string, unknown>) => void;
+}
+
+interface ViewerPaneRef {
+  focusScene: () => void;
+}
+
+const ViewerPane = forwardRef<ViewerPaneRef, ViewerPaneProps>(function ViewerPane(props, ref) {
+  const {
+    splatUrl, trajectoryUrlA, trajectoryUrlB,
+    showVehicleA, showVehicleB, showAccidentPoint, showTrajectoryLines,
+    autoPlay, playbackSpeed, playbackLoop, onStatusChange, onLoadedMeta,
+  } = props;
+
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const overlayCanvasRef = useRef<HTMLCanvasElement>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const engineRef = useRef<any>(null);
+  const orbitStateRef = useRef<OrbitState | null>(null);
+  const uiStateRef = useRef({ showVehicleA, showVehicleB, showAccidentPoint, showTrajectoryLines, autoPlay, playbackSpeed, playbackLoop });
+
+  // 샘플 궤적과 데모 차량 모델이 항상 있으므로 항상 3D 엔진 실행
+  const noAssetsProvided = false;
+
+  useEffect(() => {
+    uiStateRef.current = { showVehicleA, showVehicleB, showAccidentPoint, showTrajectoryLines, autoPlay, playbackSpeed, playbackLoop };
+  }, [showVehicleA, showVehicleB, showAccidentPoint, showTrajectoryLines, autoPlay, playbackSpeed, playbackLoop]);
+
+  useEffect(() => {
+    if (noAssetsProvided) {
+      onLoadedMeta({});
+      onStatusChange({ phase: 'idle', message: '' });
+      return;
+    }
+
+    let disposed = false;
+    let rafId = 0;
+    let resizeHandler: (() => void) | null = null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let localRendererCanvas: any = null;
+
+    async function init() {
+      if (!wrapRef.current || !overlayCanvasRef.current) return;
+      onStatusChange({ phase: 'loading', message: '뷰어 로딩 중' });
+
+      try {
+        const [SPLAT, THREE, gltfModule] = await Promise.all([
+          import('gsplat'),
+          import('three'),
+          import('three/examples/jsm/loaders/GLTFLoader.js'),
+        ]);
+        if (disposed) return;
+
+        const { GLTFLoader } = gltfModule;
+        const container = wrapRef.current!;
+        const overlayCanvas = overlayCanvasRef.current!;
+
+        const splatRenderer = new SPLAT.WebGLRenderer();
+        localRendererCanvas = splatRenderer.canvas;
+        localRendererCanvas.className = 'absolute inset-0 h-full w-full';
+        localRendererCanvas.style.cssText = 'width:100%;height:100%;pointer-events:auto;background:radial-gradient(circle at top,#111827,#020617);touch-action:none;';
+        container.prepend(localRendererCanvas);
+
+        const splatScene = new SPLAT.Scene();
+        const splatCamera = new SPLAT.Camera();
+        const splatControls = new SPLAT.OrbitControls(splatCamera, splatRenderer.canvas);
+
+        const overlayRenderer = new THREE.WebGLRenderer({ canvas: overlayCanvas, antialias: true, alpha: true });
+        overlayRenderer.setPixelRatio(window.devicePixelRatio || 1);
+        overlayRenderer.setClearColor(0x000000, 0);
+
+        const overlayScene = new THREE.Scene();
+        const overlayCamera = new THREE.PerspectiveCamera(55, 1, 0.01, 500);
+        overlayScene.add(new THREE.AmbientLight(0xffffff, 1.3));
+        const dir = new THREE.DirectionalLight(0xffffff, 1.2);
+        dir.position.set(6, 10, 5);
+        overlayScene.add(dir);
+        const fill = new THREE.DirectionalLight(0xffffff, 0.5);
+        fill.position.set(-6, 4, -3);
+        overlayScene.add(fill);
+        overlayScene.add(new THREE.GridHelper(30, 30, 0x64748b, 0x334155));
+        const ground = new THREE.Mesh(new THREE.PlaneGeometry(40, 40), new THREE.MeshStandardMaterial({ color: 0x0f172a, transparent: true, opacity: 0.35 }));
+        ground.rotation.x = -Math.PI / 2;
+        overlayScene.add(ground);
+
+        const trajectoryGroup = new THREE.Group();
+        const vehicleGroup = new THREE.Group();
+        const markerGroup = new THREE.Group();
+        overlayScene.add(trajectoryGroup, vehicleGroup, markerGroup);
+
+        const accidentMarker = new THREE.Mesh(new THREE.CylinderGeometry(0.18, 0.18, 0.05, 24), new THREE.MeshStandardMaterial({ color: 0xf59e0b }));
+        markerGroup.add(accidentMarker);
+
+        const [trajResultA, trajResultB, vehicleResultA, vehicleResultB, splatResult] = await Promise.all([
+          loadTrajectoryJson(trajectoryUrlA, sampleTrajectoryA),
+          loadTrajectoryJson(trajectoryUrlB, sampleTrajectoryB),
+          loadVehicleModel({ THREE, GLTFLoader, url: DEMO_VEHICLE_URL_A, fallbackColor: 0x2563eb }),
+          loadVehicleModel({ THREE, GLTFLoader, url: DEMO_VEHICLE_URL_B, fallbackColor: 0xef4444 }),
+          loadSplatScene({ SPLAT, url: splatUrl, scene: splatScene }),
+        ]);
+        if (disposed) return;
+
+        const trajectoryA = trajResultA.points;
+        const trajectoryB = trajResultB.points;
+        const accidentPoint = getAccidentPoint(trajectoryA, trajectoryB);
+        accidentMarker.position.set(accidentPoint[0], accidentPoint[1], accidentPoint[2]);
+
+        const framedTarget = getTrajectoryCenter(trajectoryA, trajectoryB);
+        const framedPosition = getFramedCameraPosition(framedTarget, trajectoryA, trajectoryB);
+
+        const vehicleA = vehicleResultA.model;
+        const vehicleB = vehicleResultB.model;
+        vehicleA.rotation.y += Math.PI;
+        vehicleB.rotation.y += Math.PI;
+        vehicleGroup.add(vehicleA, vehicleB);
+
+        const lineA = new THREE.Line(
+          new THREE.BufferGeometry().setFromPoints(trajectoryA.map((p: unknown) => { const c = getPointComponents(p); return new THREE.Vector3(c.x, c.y, c.z); })),
+          new THREE.LineBasicMaterial({ color: 0x60a5fa })
+        );
+        const lineB = new THREE.Line(
+          new THREE.BufferGeometry().setFromPoints(trajectoryB.map((p: unknown) => { const c = getPointComponents(p); return new THREE.Vector3(c.x, c.y, c.z); })),
+          new THREE.LineBasicMaterial({ color: 0xf87171 })
+        );
+        trajectoryGroup.add(lineA, lineB);
+
+        orbitStateRef.current = computeOrbitStateFromFrame(framedTarget, framedPosition);
+        applyOrbitStateToCamera(orbitStateRef.current, splatCamera, splatControls);
+        overlayCamera.position.set(framedPosition[0], framedPosition[1], framedPosition[2]);
+        overlayCamera.lookAt(framedTarget[0], framedTarget[1], framedTarget[2]);
+
+        // 마우스/터치 컨트롤
+        const cs = { mode: null as string | null, pointerId: null as number | null, lastX: 0, lastY: 0 };
+
+        const onPointerDown = (e: PointerEvent) => {
+          if (!orbitStateRef.current) return;
+          cs.mode = e.button === 0 && !e.shiftKey ? 'rotate' : e.button === 2 || (e.button === 0 && e.shiftKey) ? 'pan' : null;
+          if (!cs.mode) return;
+          cs.pointerId = e.pointerId; cs.lastX = e.clientX; cs.lastY = e.clientY;
+          try { localRendererCanvas.setPointerCapture(e.pointerId); } catch (_) {}
+          e.preventDefault(); e.stopPropagation();
+        };
+        const onPointerMove = (e: PointerEvent) => {
+          if (!orbitStateRef.current || !cs.mode) return;
+          if (cs.pointerId !== null && e.pointerId !== cs.pointerId) return;
+          const dx = e.clientX - cs.lastX, dy = e.clientY - cs.lastY;
+          cs.lastX = e.clientX; cs.lastY = e.clientY;
+          if (cs.mode === 'rotate') {
+            orbitStateRef.current.theta -= dx * CAMERA_ROTATE_SPEED;
+            orbitStateRef.current.phi = Math.min(CAMERA_MAX_PHI, Math.max(CAMERA_MIN_PHI, orbitStateRef.current.phi - dy * CAMERA_ROTATE_SPEED));
+            applyOrbitStateToCamera(orbitStateRef.current, splatCamera, splatControls);
+          } else {
+            panCameraByScreenDelta(THREE, orbitStateRef.current, splatCamera, splatControls, dx, dy);
+          }
+          e.preventDefault();
+        };
+        const clearPtr = () => { cs.mode = null; cs.pointerId = null; };
+        const onPointerUp = () => { try { localRendererCanvas.releasePointerCapture(cs.pointerId!); } catch (_) {} clearPtr(); };
+        const onWheel = (e: WheelEvent) => { if (!orbitStateRef.current) return; e.preventDefault(); dollyCameraTowardTarget(orbitStateRef.current, splatCamera, splatControls, e.deltaY); };
+        const onContextMenu = (e: Event) => e.preventDefault();
+        const onKeyDown = (e: KeyboardEvent) => {
+          if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) return;
+          e.preventDefault(); // 페이지 스크롤 방지
+          if (!orbitStateRef.current) return;
+          const state = orbitStateRef.current;
+          const pos = safeReadGsplatPosition(splatCamera);
+          if (!pos) return;
+          const forward = new THREE.Vector3(state.target[0] - pos.x, 0, state.target[2] - pos.z).normalize();
+          const right = new THREE.Vector3().crossVectors(forward, new THREE.Vector3(0, 1, 0)).normalize();
+          const ms = state.distance * 0.05;
+          const move = new THREE.Vector3();
+          if (e.key === 'ArrowUp') move.addScaledVector(forward, ms);
+          if (e.key === 'ArrowDown') move.addScaledVector(forward, -ms);
+          if (e.key === 'ArrowLeft') move.addScaledVector(right, -ms);
+          if (e.key === 'ArrowRight') move.addScaledVector(right, ms);
+          state.target = [state.target[0] + move.x, state.target[1], state.target[2] + move.z];
+          applyOrbitStateToCamera(state, splatCamera, splatControls);
+        };
+
+        localRendererCanvas.addEventListener('pointerdown', onPointerDown);
+        localRendererCanvas.addEventListener('pointermove', onPointerMove);
+        localRendererCanvas.addEventListener('pointerup', onPointerUp);
+        localRendererCanvas.addEventListener('pointercancel', clearPtr);
+        localRendererCanvas.addEventListener('wheel', onWheel, { passive: false });
+        localRendererCanvas.addEventListener('contextmenu', onContextMenu);
+        window.addEventListener('keydown', onKeyDown);
+
+        const resize = () => {
+          const rect = container.getBoundingClientRect();
+          const w = Math.max(1, Math.floor(rect.width)), h = Math.max(1, Math.floor(rect.height));
+          splatRenderer.setSize(w, h);
+          overlayRenderer.setSize(w, h, false);
+          overlayCamera.aspect = w / h;
+          overlayCamera.updateProjectionMatrix();
+        };
+        resize();
+        resizeHandler = resize;
+        window.addEventListener('resize', resizeHandler);
+
+        const startTimeRef = { current: performance.now() };
+        const pausePlayheadRef = { current: 0 };
+        const lastAutoPlayRef = { current: uiStateRef.current.autoPlay };
+
+        engineRef.current = {
+          canvasHandlers: { onPointerDown, onPointerMove, onPointerUp, onPointerCancel: clearPtr, onWheel, onContextMenu },
+          keyHandler: onKeyDown,
+          focusScene: () => {
+            orbitStateRef.current = computeOrbitStateFromFrame(framedTarget, framedPosition);
+            applyOrbitStateToCamera(orbitStateRef.current, splatCamera, splatControls);
+            overlayCamera.position.set(framedPosition[0], framedPosition[1], framedPosition[2]);
+            overlayCamera.lookAt(framedTarget[0], framedTarget[1], framedTarget[2]);
+          },
+          splatRenderer, splatScene, splatCamera, splatControls,
+          overlayRenderer, overlayScene, overlayCamera,
+          trajectoryA, trajectoryB, vehicleA, vehicleB, lineA, lineB,
+          accidentMarker, ground, startTimeRef, pausePlayheadRef, lastAutoPlayRef,
+          hasSplat: splatResult.ok,
+        };
+
+        const closestPair = findClosestPointPair(trajectoryA, trajectoryB);
+        onLoadedMeta({
+          trajectoryHasTimeA: trajectoryHasTimestamps(trajectoryA),
+          trajectoryHasTimeB: trajectoryHasTimestamps(trajectoryB),
+          collisionSpeedA: closestPair ? computePointSpeedKmh(trajectoryA, closestPair.indexA) : null,
+          collisionSpeedB: closestPair ? computePointSpeedKmh(trajectoryB, closestPair.indexB) : null,
+          collisionDistanceM: closestPair ? Math.sqrt(closestPair.distanceSq) : null,
+        });
+        onStatusChange({ phase: 'ready', message: '뷰어 준비 완료' });
+
+        const animate = (now: number) => {
+          if (disposed || !engineRef.current) return;
+          const engine = engineRef.current;
+          const state = uiStateRef.current;
+
+          if (engine.hasSplat) {
+            copyGsplatCameraToThreeCamera(engine.splatCamera, engine.overlayCamera);
+          } else if (orbitStateRef.current) {
+            const s = orbitStateRef.current;
+            engine.overlayCamera.position.set(
+              s.target[0] + s.distance * Math.sin(s.phi) * Math.cos(s.theta),
+              s.target[1] + s.distance * Math.cos(s.phi),
+              s.target[2] + s.distance * Math.sin(s.phi) * Math.sin(s.theta)
+            );
+            engine.overlayCamera.lookAt(s.target[0], s.target[1], s.target[2]);
+          }
+
+          if (engine.lastAutoPlayRef.current !== state.autoPlay) {
+            if (state.autoPlay) engine.startTimeRef.current = now - (engine.pausePlayheadRef.current / Math.max(0.0001, state.playbackSpeed)) * 1000;
+            engine.lastAutoPlayRef.current = state.autoPlay;
+          }
+
+          const baseElapsed = state.autoPlay ? ((now - engine.startTimeRef.current) / 1000) * state.playbackSpeed : engine.pausePlayheadRef.current;
+          const durationA = Math.max(1e-6, getTrajectoryDuration(engine.trajectoryA));
+          const durationB = Math.max(1e-6, getTrajectoryDuration(engine.trajectoryB));
+          const usesTimeA = trajectoryHasTimestamps(engine.trajectoryA);
+          const usesTimeB = trajectoryHasTimestamps(engine.trajectoryB);
+          const sampleInputA = usesTimeA ? (state.playbackLoop ? baseElapsed % durationA : Math.min(baseElapsed, durationA)) : (state.playbackLoop ? baseElapsed % 1 : Math.min(baseElapsed, 0.999999));
+          const sampleInputB = usesTimeB ? (state.playbackLoop ? baseElapsed % durationB : Math.min(baseElapsed, durationB)) : (state.playbackLoop ? baseElapsed % 1 : Math.min(baseElapsed, 0.999999));
+          engine.pausePlayheadRef.current = baseElapsed;
+
+          const sA = samplePath(engine.trajectoryA, sampleInputA);
+          const sB = samplePath(engine.trajectoryB, sampleInputB);
+
+          engine.vehicleA.visible = state.showVehicleA;
+          engine.vehicleB.visible = state.showVehicleB;
+          engine.lineA.visible = state.showTrajectoryLines;
+          engine.lineB.visible = state.showTrajectoryLines;
+          engine.accidentMarker.visible = state.showAccidentPoint;
+
+          engine.vehicleA.position.set(sA.position[0], sA.position[1], sA.position[2]);
+          engine.vehicleB.position.set(sB.position[0], sB.position[1], sB.position[2]);
+          engine.vehicleA.lookAt(sA.next[0], sA.position[1], sA.next[2]);
+          engine.vehicleB.lookAt(sB.next[0], sB.position[1], sB.next[2]);
+
+          if (engine.hasSplat) engine.splatRenderer.render(engine.splatScene, engine.splatCamera);
+          engine.overlayRenderer.render(engine.overlayScene, engine.overlayCamera);
+          rafId = requestAnimationFrame(animate);
+        };
+        rafId = requestAnimationFrame(animate);
+      } catch (error) {
+        onStatusChange({ phase: 'error', message: (error as Error)?.message || '뷰어 초기화 실패' });
+      }
+    }
+
+    init();
+
+    return () => {
+      disposed = true;
+      const engine = engineRef.current;
+      if (rafId) cancelAnimationFrame(rafId);
+      if (resizeHandler) window.removeEventListener('resize', resizeHandler);
+      if (engine) {
+        if (engine.keyHandler) window.removeEventListener('keydown', engine.keyHandler);
+        try {
+          const ch = engine.canvasHandlers;
+          if (localRendererCanvas && ch) {
+            localRendererCanvas.removeEventListener('pointerdown', ch.onPointerDown);
+            localRendererCanvas.removeEventListener('pointermove', ch.onPointerMove);
+            localRendererCanvas.removeEventListener('pointerup', ch.onPointerUp);
+            localRendererCanvas.removeEventListener('pointercancel', ch.onPointerCancel);
+            localRendererCanvas.removeEventListener('wheel', ch.onWheel);
+            localRendererCanvas.removeEventListener('contextmenu', ch.onContextMenu);
+          }
+          engine.splatControls?.dispose?.();
+          engine.overlayRenderer?.dispose?.();
+          disposeThreeObject(engine.vehicleA);
+          disposeThreeObject(engine.vehicleB);
+          engine.lineA?.geometry?.dispose?.();
+          engine.lineA?.material?.dispose?.();
+          engine.lineB?.geometry?.dispose?.();
+          engine.lineB?.material?.dispose?.();
+          engine.accidentMarker?.geometry?.dispose?.();
+          engine.accidentMarker?.material?.dispose?.();
+          engine.ground?.geometry?.dispose?.();
+          engine.ground?.material?.dispose?.();
+        } catch (_) {}
+      }
+      engineRef.current = null;
+      orbitStateRef.current = null;
+      if (localRendererCanvas?.parentNode) localRendererCanvas.parentNode.removeChild(localRendererCanvas);
+    };
+  }, [splatUrl, trajectoryUrlA, trajectoryUrlB, noAssetsProvided, onStatusChange, onLoadedMeta]);
+
+  useImperativeHandle(ref, () => ({
+    focusScene: () => engineRef.current?.focusScene?.(),
+  }));
+
+  return (
+    <div ref={wrapRef} className="relative h-[600px] overflow-hidden rounded-2xl border border-[#dae3dd] bg-[#0a1e14]">
+      {!noAssetsProvided && (
+        <canvas ref={overlayCanvasRef} className="pointer-events-none absolute inset-0 z-10 h-full w-full" />
+      )}
+      {noAssetsProvided && (
+        <HtmlFallbackPreview
+          showVehicleA={showVehicleA} showVehicleB={showVehicleB}
+          showAccidentPoint={showAccidentPoint} showTrajectoryLines={showTrajectoryLines}
+        />
+      )}
+      <div className="pointer-events-none absolute bottom-4 right-4 z-20 rounded-xl bg-black/45 px-3 py-2 text-xs text-white backdrop-blur">
+        좌클릭 드래그 회전 · 방향키 이동 · 휠 줌
+      </div>
+    </div>
+  );
+});
+
+// ─── 메인 컴포넌트 ────────────────────────────────────────────────────────────
+
+export function Viewer3D({ jobId, resultUrl, trajectoryUrl }: Viewer3DProps) {
+  const [status, setStatus] = useState({ phase: 'idle', message: '' });
+  const [showVehicleA, setShowVehicleA] = useState(true);
+  const [showVehicleB, setShowVehicleB] = useState(true);
+  const [showTrajectoryLines, setShowTrajectoryLines] = useState(true);
+  const [showAccidentPoint, setShowAccidentPoint] = useState(true);
+  const [autoPlay, setAutoPlay] = useState(true);
+  const [playbackSpeed, setPlaybackSpeed] = useState(1.0);
+  const [loadedMeta, setLoadedMeta] = useState<Record<string, unknown>>({});
+
+  const viewerPaneRef = useRef<ViewerPaneRef>(null);
+  const handleLoadedMeta = useCallback((meta: Record<string, unknown>) => setLoadedMeta(meta || {}), []);
+
+  return (
+    <ViewerErrorBoundary>
+      <div className="bg-white rounded-lg shadow-sm p-6 mb-8">
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <h2 className="text-[#20543d]">3D 사고 복원 뷰어</h2>
+            <p className="text-sm text-[#8a9590] mt-1">Job ID: {jobId}</p>
+          </div>
+          {status.phase === 'loading' && (
+            <div className="flex items-center gap-2 text-sm text-[#299283]">
+              <div className="w-4 h-4 border-2 border-[#299283] border-t-transparent rounded-full animate-spin" />
+              {status.message}
+            </div>
+          )}
+          {status.phase === 'error' && (
+            <div className="text-sm text-red-600">{status.message}</div>
+          )}
+        </div>
+
+        {/* 뷰어 + 컨트롤 패널 */}
+        <div className="grid gap-4 lg:grid-cols-[220px_1fr]">
+          {/* 컨트롤 패널 */}
+          <div className="space-y-4">
+            {/* 표시 옵션 */}
+            <div className="rounded-xl border border-[#dae3dd] p-4">
+              <p className="text-sm font-semibold text-[#5a665e] mb-3">표시 옵션</p>
+              <div className="space-y-2">
+                {[
+                  { label: '차량 A', value: showVehicleA, onChange: setShowVehicleA },
+                  { label: '차량 B', value: showVehicleB, onChange: setShowVehicleB },
+                  { label: '궤적 라인', value: showTrajectoryLines, onChange: setShowTrajectoryLines },
+                  { label: '사고 지점', value: showAccidentPoint, onChange: setShowAccidentPoint },
+                ].map(({ label, value, onChange }) => (
+                  <label key={label} className="flex items-center justify-between rounded-lg bg-[#f7f9f8] px-3 py-2 text-sm cursor-pointer">
+                    <span className="text-[#5a665e]">{label}</span>
+                    <input type="checkbox" checked={value} onChange={(e) => onChange(e.target.checked)} className="h-4 w-4 accent-indigo-600" />
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            {/* 재생 옵션 */}
+            <div className="rounded-xl border border-[#dae3dd] p-4">
+              <p className="text-sm font-semibold text-[#5a665e] mb-3">재생 옵션</p>
+              <div className="space-y-3">
+                <button
+                  onClick={() => setAutoPlay((v) => !v)}
+                  className="w-full rounded-lg border border-[#dae3dd] bg-white px-3 py-2 text-sm font-medium text-[#5a665e] hover:bg-[#f7f9f8] transition-colors"
+                >
+                  {autoPlay ? '⏸ 정지' : '▶ 재생'}
+                </button>
+                <button
+                  onClick={() => viewerPaneRef.current?.focusScene?.()}
+                  className="w-full rounded-lg border border-[#dae3dd] bg-white px-3 py-2 text-sm font-medium text-[#5a665e] hover:bg-[#f7f9f8] transition-colors"
+                >
+                  화면 맞추기
+                </button>
+                <div>
+                  <div className="flex justify-between text-xs text-[#5a665e] mb-1">
+                    <span>재생 배속</span>
+                    <span>{playbackSpeed.toFixed(2)}x</span>
+                  </div>
+                  <input
+                    type="range" min="0.1" max="3" step="0.05"
+                    value={playbackSpeed}
+                    onChange={(e) => setPlaybackSpeed(Number(e.target.value))}
+                    className="w-full accent-indigo-600"
+                  />
+                </div>
+              </div>
+            </div>
+
+            {/* 충돌 정보 */}
+            <div className="rounded-xl border border-[#dae3dd] p-4">
+              <p className="text-sm font-semibold text-[#5a665e] mb-3">충돌 순간 속도</p>
+              <div className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-[#8a9590]">차량 A</span>
+                  <span className="font-semibold text-[#299283]">{formatSpeedKmh(loadedMeta.collisionSpeedA as number)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-[#8a9590]">차량 B</span>
+                  <span className="font-semibold text-red-500">{formatSpeedKmh(loadedMeta.collisionSpeedB as number)}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* 3D 뷰 */}
+          <ViewerPane
+            key={`${resultUrl ?? ''}-${trajectoryUrl ?? ''}`}
+            ref={viewerPaneRef}
+            splatUrl={resultUrl}
+            trajectoryUrlA={trajectoryUrl}
+            trajectoryUrlB={undefined}
+            showVehicleA={showVehicleA}
+            showVehicleB={showVehicleB}
+            showTrajectoryLines={showTrajectoryLines}
+            showAccidentPoint={showAccidentPoint}
+            autoPlay={autoPlay}
+            playbackSpeed={playbackSpeed}
+            playbackLoop={true}
+            onStatusChange={setStatus}
+            onLoadedMeta={handleLoadedMeta}
+          />
+        </div>
+      </div>
+    </ViewerErrorBoundary>
+  );
+}

--- a/src/app/figma/ImageWithFallback.tsx
+++ b/src/app/figma/ImageWithFallback.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react'
+
+const ERROR_IMG_SRC =
+  'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODgiIGhlaWdodD0iODgiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgc3Ryb2tlPSIjMDAwIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBvcGFjaXR5PSIuMyIgZmlsbD0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIzLjciPjxyZWN0IHg9IjE2IiB5PSIxNiIgd2lkdGg9IjU2IiBoZWlnaHQ9IjU2IiByeD0iNiIvPjxwYXRoIGQ9Im0xNiA1OCAxNi0xOCAzMiAzMiIvPjxjaXJjbGUgY3g9IjUzIiBjeT0iMzUiIHI9IjciLz48L3N2Zz4KCg=='
+
+export function ImageWithFallback(props: React.ImgHTMLAttributes<HTMLImageElement>) {
+  const [didError, setDidError] = useState(false)
+
+  const handleError = () => {
+    setDidError(true)
+  }
+
+  const { src, alt, style, className, ...rest } = props
+
+  return didError ? (
+    <div
+      className={`inline-block bg-gray-100 text-center align-middle ${className ?? ''}`}
+      style={style}
+    >
+      <div className="flex items-center justify-center w-full h-full">
+        <img src={ERROR_IMG_SRC} alt="Error loading image" {...rest} data-original-url={src} />
+      </div>
+    </div>
+  ) : (
+    <img src={src} alt={alt} className={className} style={style} {...rest} onError={handleError} />
+  )
+}

--- a/src/app/ui/accordion.tsx
+++ b/src/app/ui/accordion.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import * as React from "react";
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import { ChevronDownIcon } from "lucide-react";
+
+import { cn } from "./utils";
+
+function Accordion({
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return <AccordionPrimitive.Root data-slot="accordion" {...props} />;
+}
+
+function AccordionItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn("border-b last:border-b-0", className)}
+      {...props}
+    />
+  );
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  );
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      data-slot="accordion-content"
+      className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+      {...props}
+    >
+      <div className={cn("pt-0 pb-4", className)}>{children}</div>
+    </AccordionPrimitive.Content>
+  );
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/src/app/ui/alert-dialog.tsx
+++ b/src/app/ui/alert-dialog.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import * as React from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+
+import { cn } from "./utils";
+import { buttonVariants } from "./button";
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  );
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  );
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/src/app/ui/alert.tsx
+++ b/src/app/ui/alert.tsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "./utils";
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Alert, AlertTitle, AlertDescription };

--- a/src/app/ui/aspect-ratio.tsx
+++ b/src/app/ui/aspect-ratio.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import * as AspectRatioPrimitive from "@radix-ui/react-aspect-ratio";
+
+function AspectRatio({
+  ...props
+}: React.ComponentProps<typeof AspectRatioPrimitive.Root>) {
+  return <AspectRatioPrimitive.Root data-slot="aspect-ratio" {...props} />;
+}
+
+export { AspectRatio };

--- a/src/app/ui/avatar.tsx
+++ b/src/app/ui/avatar.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import * as React from "react";
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
+
+import { cn } from "./utils";
+
+function Avatar({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root>) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      className={cn(
+        "relative flex size-10 shrink-0 overflow-hidden rounded-full",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn("aspect-square size-full", className)}
+      {...props}
+    />
+  );
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "bg-muted flex size-full items-center justify-center rounded-full",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Avatar, AvatarImage, AvatarFallback };

--- a/src/app/ui/badge.tsx
+++ b/src/app/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "./utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "span";
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/src/app/ui/breadcrumb.tsx
+++ b/src/app/ui/breadcrumb.tsx
@@ -1,0 +1,109 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { ChevronRight, MoreHorizontal } from "lucide-react";
+
+import { cn } from "./utils";
+
+function Breadcrumb({ ...props }: React.ComponentProps<"nav">) {
+  return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />;
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        "text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn("inline-flex items-center gap-1.5", className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbLink({
+  asChild,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean;
+}) {
+  const Comp = asChild ? Slot : "a";
+
+  return (
+    <Comp
+      data-slot="breadcrumb-link"
+      className={cn("hover:text-foreground transition-colors", className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn("text-foreground font-normal", className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("[&>svg]:size-3.5", className)}
+      {...props}
+    >
+      {children ?? <ChevronRight />}
+    </li>
+  );
+}
+
+function BreadcrumbEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontal className="size-4" />
+      <span className="sr-only">More</span>
+    </span>
+  );
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+};

--- a/src/app/ui/button.tsx
+++ b/src/app/ui/button.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "./utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background text-foreground hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9 rounded-md",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  }) {
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/src/app/ui/calendar.tsx
+++ b/src/app/ui/calendar.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import * as React from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { DayPicker } from "react-day-picker";
+
+import { cn } from "./utils";
+import { buttonVariants } from "./button";
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  ...props
+}: React.ComponentProps<typeof DayPicker>) {
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn("p-3", className)}
+      classNames={{
+        months: "flex flex-col sm:flex-row gap-2",
+        month: "flex flex-col gap-4",
+        caption: "flex justify-center pt-1 relative items-center w-full",
+        caption_label: "text-sm font-medium",
+        nav: "flex items-center gap-1",
+        nav_button: cn(
+          buttonVariants({ variant: "outline" }),
+          "size-7 bg-transparent p-0 opacity-50 hover:opacity-100",
+        ),
+        nav_button_previous: "absolute left-1",
+        nav_button_next: "absolute right-1",
+        table: "w-full border-collapse space-x-1",
+        head_row: "flex",
+        head_cell:
+          "text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]",
+        row: "flex w-full mt-2",
+        cell: cn(
+          "relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-range-end)]:rounded-r-md",
+          props.mode === "range"
+            ? "[&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md"
+            : "[&:has([aria-selected])]:rounded-md",
+        ),
+        day: cn(
+          buttonVariants({ variant: "ghost" }),
+          "size-8 p-0 font-normal aria-selected:opacity-100",
+        ),
+        day_range_start:
+          "day-range-start aria-selected:bg-primary aria-selected:text-primary-foreground",
+        day_range_end:
+          "day-range-end aria-selected:bg-primary aria-selected:text-primary-foreground",
+        day_selected:
+          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+        day_today: "bg-accent text-accent-foreground",
+        day_outside:
+          "day-outside text-muted-foreground aria-selected:text-muted-foreground",
+        day_disabled: "text-muted-foreground opacity-50",
+        day_range_middle:
+          "aria-selected:bg-accent aria-selected:text-accent-foreground",
+        day_hidden: "invisible",
+        ...classNames,
+      }}
+      components={{
+        IconLeft: ({ className, ...props }) => (
+          <ChevronLeft className={cn("size-4", className)} {...props} />
+        ),
+        IconRight: ({ className, ...props }) => (
+          <ChevronRight className={cn("size-4", className)} {...props} />
+        ),
+      }}
+      {...props}
+    />
+  );
+}
+
+export { Calendar };

--- a/src/app/ui/card.tsx
+++ b/src/app/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react";
+
+import { cn } from "./utils";
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 pt-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <h4
+      data-slot="card-title"
+      className={cn("leading-none", className)}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <p
+      data-slot="card-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6 [&:last-child]:pb-6", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 pb-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+};

--- a/src/app/ui/carousel.tsx
+++ b/src/app/ui/carousel.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import * as React from "react";
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from "embla-carousel-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+
+import { cn } from "./utils";
+import { Button } from "./button";
+
+type CarouselApi = UseEmblaCarouselType[1];
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
+type CarouselOptions = UseCarouselParameters[0];
+type CarouselPlugin = UseCarouselParameters[1];
+
+type CarouselProps = {
+  opts?: CarouselOptions;
+  plugins?: CarouselPlugin;
+  orientation?: "horizontal" | "vertical";
+  setApi?: (api: CarouselApi) => void;
+};
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0];
+  api: ReturnType<typeof useEmblaCarousel>[1];
+  scrollPrev: () => void;
+  scrollNext: () => void;
+  canScrollPrev: boolean;
+  canScrollNext: boolean;
+} & CarouselProps;
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null);
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext);
+
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />");
+  }
+
+  return context;
+}
+
+function Carousel({
+  orientation = "horizontal",
+  opts,
+  setApi,
+  plugins,
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & CarouselProps) {
+  const [carouselRef, api] = useEmblaCarousel(
+    {
+      ...opts,
+      axis: orientation === "horizontal" ? "x" : "y",
+    },
+    plugins,
+  );
+  const [canScrollPrev, setCanScrollPrev] = React.useState(false);
+  const [canScrollNext, setCanScrollNext] = React.useState(false);
+
+  const onSelect = React.useCallback((api: CarouselApi) => {
+    if (!api) return;
+    setCanScrollPrev(api.canScrollPrev());
+    setCanScrollNext(api.canScrollNext());
+  }, []);
+
+  const scrollPrev = React.useCallback(() => {
+    api?.scrollPrev();
+  }, [api]);
+
+  const scrollNext = React.useCallback(() => {
+    api?.scrollNext();
+  }, [api]);
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        scrollPrev();
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        scrollNext();
+      }
+    },
+    [scrollPrev, scrollNext],
+  );
+
+  React.useEffect(() => {
+    if (!api || !setApi) return;
+    setApi(api);
+  }, [api, setApi]);
+
+  React.useEffect(() => {
+    if (!api) return;
+    onSelect(api);
+    api.on("reInit", onSelect);
+    api.on("select", onSelect);
+
+    return () => {
+      api?.off("select", onSelect);
+    };
+  }, [api, onSelect]);
+
+  return (
+    <CarouselContext.Provider
+      value={{
+        carouselRef,
+        api: api,
+        opts,
+        orientation:
+          orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+        scrollPrev,
+        scrollNext,
+        canScrollPrev,
+        canScrollNext,
+      }}
+    >
+      <div
+        onKeyDownCapture={handleKeyDown}
+        className={cn("relative", className)}
+        role="region"
+        aria-roledescription="carousel"
+        data-slot="carousel"
+        {...props}
+      >
+        {children}
+      </div>
+    </CarouselContext.Provider>
+  );
+}
+
+function CarouselContent({ className, ...props }: React.ComponentProps<"div">) {
+  const { carouselRef, orientation } = useCarousel();
+
+  return (
+    <div
+      ref={carouselRef}
+      className="overflow-hidden"
+      data-slot="carousel-content"
+    >
+      <div
+        className={cn(
+          "flex",
+          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
+  const { orientation } = useCarousel();
+
+  return (
+    <div
+      role="group"
+      aria-roledescription="slide"
+      data-slot="carousel-item"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        orientation === "horizontal" ? "pl-4" : "pt-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CarouselPrevious({
+  className,
+  variant = "outline",
+  size = "icon",
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel();
+
+  return (
+    <Button
+      data-slot="carousel-previous"
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute size-8 rounded-full",
+        orientation === "horizontal"
+          ? "top-1/2 -left-12 -translate-y-1/2"
+          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        className,
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ArrowLeft />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  );
+}
+
+function CarouselNext({
+  className,
+  variant = "outline",
+  size = "icon",
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { orientation, scrollNext, canScrollNext } = useCarousel();
+
+  return (
+    <Button
+      data-slot="carousel-next"
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute size-8 rounded-full",
+        orientation === "horizontal"
+          ? "top-1/2 -right-12 -translate-y-1/2"
+          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        className,
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ArrowRight />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  );
+}
+
+export {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+};

--- a/src/app/ui/chart.tsx
+++ b/src/app/ui/chart.tsx
@@ -1,0 +1,353 @@
+"use client";
+
+import * as React from "react";
+import * as RechartsPrimitive from "recharts";
+
+import { cn } from "./utils";
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const;
+
+export type ChartConfig = {
+  [k in string]: {
+    label?: React.ReactNode;
+    icon?: React.ComponentType;
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  );
+};
+
+type ChartContextProps = {
+  config: ChartConfig;
+};
+
+const ChartContext = React.createContext<ChartContextProps | null>(null);
+
+function useChart() {
+  const context = React.useContext(ChartContext);
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />");
+  }
+
+  return context;
+}
+
+function ChartContainer({
+  id,
+  className,
+  children,
+  config,
+  ...props
+}: React.ComponentProps<"div"> & {
+  config: ChartConfig;
+  children: React.ComponentProps<
+    typeof RechartsPrimitive.ResponsiveContainer
+  >["children"];
+}) {
+  const uniqueId = React.useId();
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`;
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-slot="chart"
+        data-chart={chartId}
+        className={cn(
+          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          className,
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer>
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  );
+}
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(
+    ([, config]) => config.theme || config.color,
+  );
+
+  if (!colorConfig.length) {
+    return null;
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color =
+      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
+      itemConfig.color;
+    return color ? `  --color-${key}: ${color};` : null;
+  })
+  .join("\n")}
+}
+`,
+          )
+          .join("\n"),
+      }}
+    />
+  );
+};
+
+const ChartTooltip = RechartsPrimitive.Tooltip;
+
+function ChartTooltipContent({
+  active,
+  payload,
+  className,
+  indicator = "dot",
+  hideLabel = false,
+  hideIndicator = false,
+  label,
+  labelFormatter,
+  labelClassName,
+  formatter,
+  color,
+  nameKey,
+  labelKey,
+}: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+  React.ComponentProps<"div"> & {
+    hideLabel?: boolean;
+    hideIndicator?: boolean;
+    indicator?: "line" | "dot" | "dashed";
+    nameKey?: string;
+    labelKey?: string;
+  }) {
+  const { config } = useChart();
+
+  const tooltipLabel = React.useMemo(() => {
+    if (hideLabel || !payload?.length) {
+      return null;
+    }
+
+    const [item] = payload;
+    const key = `${labelKey || item?.dataKey || item?.name || "value"}`;
+    const itemConfig = getPayloadConfigFromPayload(config, item, key);
+    const value =
+      !labelKey && typeof label === "string"
+        ? config[label as keyof typeof config]?.label || label
+        : itemConfig?.label;
+
+    if (labelFormatter) {
+      return (
+        <div className={cn("font-medium", labelClassName)}>
+          {labelFormatter(value, payload)}
+        </div>
+      );
+    }
+
+    if (!value) {
+      return null;
+    }
+
+    return <div className={cn("font-medium", labelClassName)}>{value}</div>;
+  }, [
+    label,
+    labelFormatter,
+    payload,
+    hideLabel,
+    labelClassName,
+    config,
+    labelKey,
+  ]);
+
+  if (!active || !payload?.length) {
+    return null;
+  }
+
+  const nestLabel = payload.length === 1 && indicator !== "dot";
+
+  return (
+    <div
+      className={cn(
+        "border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl",
+        className,
+      )}
+    >
+      {!nestLabel ? tooltipLabel : null}
+      <div className="grid gap-1.5">
+        {payload.map((item, index) => {
+          const key = `${nameKey || item.name || item.dataKey || "value"}`;
+          const itemConfig = getPayloadConfigFromPayload(config, item, key);
+          const indicatorColor = color || item.payload.fill || item.color;
+
+          return (
+            <div
+              key={item.dataKey}
+              className={cn(
+                "[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5",
+                indicator === "dot" && "items-center",
+              )}
+            >
+              {formatter && item?.value !== undefined && item.name ? (
+                formatter(item.value, item.name, item, index, item.payload)
+              ) : (
+                <>
+                  {itemConfig?.icon ? (
+                    <itemConfig.icon />
+                  ) : (
+                    !hideIndicator && (
+                      <div
+                        className={cn(
+                          "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
+                          {
+                            "h-2.5 w-2.5": indicator === "dot",
+                            "w-1": indicator === "line",
+                            "w-0 border-[1.5px] border-dashed bg-transparent":
+                              indicator === "dashed",
+                            "my-0.5": nestLabel && indicator === "dashed",
+                          },
+                        )}
+                        style={
+                          {
+                            "--color-bg": indicatorColor,
+                            "--color-border": indicatorColor,
+                          } as React.CSSProperties
+                        }
+                      />
+                    )
+                  )}
+                  <div
+                    className={cn(
+                      "flex flex-1 justify-between leading-none",
+                      nestLabel ? "items-end" : "items-center",
+                    )}
+                  >
+                    <div className="grid gap-1.5">
+                      {nestLabel ? tooltipLabel : null}
+                      <span className="text-muted-foreground">
+                        {itemConfig?.label || item.name}
+                      </span>
+                    </div>
+                    {item.value && (
+                      <span className="text-foreground font-mono font-medium tabular-nums">
+                        {item.value.toLocaleString()}
+                      </span>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+const ChartLegend = RechartsPrimitive.Legend;
+
+function ChartLegendContent({
+  className,
+  hideIcon = false,
+  payload,
+  verticalAlign = "bottom",
+  nameKey,
+}: React.ComponentProps<"div"> &
+  Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
+    hideIcon?: boolean;
+    nameKey?: string;
+  }) {
+  const { config } = useChart();
+
+  if (!payload?.length) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center gap-4",
+        verticalAlign === "top" ? "pb-3" : "pt-3",
+        className,
+      )}
+    >
+      {payload.map((item) => {
+        const key = `${nameKey || item.dataKey || "value"}`;
+        const itemConfig = getPayloadConfigFromPayload(config, item, key);
+
+        return (
+          <div
+            key={item.value}
+            className={cn(
+              "[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3",
+            )}
+          >
+            {itemConfig?.icon && !hideIcon ? (
+              <itemConfig.icon />
+            ) : (
+              <div
+                className="h-2 w-2 shrink-0 rounded-[2px]"
+                style={{
+                  backgroundColor: item.color,
+                }}
+              />
+            )}
+            {itemConfig?.label}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// Helper to extract item config from a payload.
+function getPayloadConfigFromPayload(
+  config: ChartConfig,
+  payload: unknown,
+  key: string,
+) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined;
+  }
+
+  const payloadPayload =
+    "payload" in payload &&
+    typeof payload.payload === "object" &&
+    payload.payload !== null
+      ? payload.payload
+      : undefined;
+
+  let configLabelKey: string = key;
+
+  if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === "string"
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string;
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[
+      key as keyof typeof payloadPayload
+    ] as string;
+  }
+
+  return configLabelKey in config
+    ? config[configLabelKey]
+    : config[key as keyof typeof config];
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+};

--- a/src/app/ui/checkbox.tsx
+++ b/src/app/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { CheckIcon } from "lucide-react";
+
+import { cn } from "./utils";
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border bg-input-background dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/src/app/ui/collapsible.tsx
+++ b/src/app/ui/collapsible.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
+
+function Collapsible({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      data-slot="collapsible-trigger"
+      {...props}
+    />
+  );
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleContent
+      data-slot="collapsible-content"
+      {...props}
+    />
+  );
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/src/app/ui/command.tsx
+++ b/src/app/ui/command.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import { SearchIcon } from "lucide-react";
+
+import { cn } from "./utils";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "./dialog";
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string;
+  description?: string;
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent className="overflow-hidden p-0">
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  );
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("bg-border -mx-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+};

--- a/src/app/ui/context-menu.tsx
+++ b/src/app/ui/context-menu.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import * as React from "react";
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
+
+import { cn } from "./utils";
+
+function ContextMenu({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />;
+}
+
+function ContextMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
+  return (
+    <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />
+  );
+}
+
+function ContextMenuGroup({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Group>) {
+  return (
+    <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />
+  );
+}
+
+function ContextMenuPortal({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Portal>) {
+  return (
+    <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />
+  );
+}
+
+function ContextMenuSub({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Sub>) {
+  return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {...props} />;
+}
+
+function ContextMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.RadioGroup>) {
+  return (
+    <ContextMenuPrimitive.RadioGroup
+      data-slot="context-menu-radio-group"
+      {...props}
+    />
+  );
+}
+
+function ContextMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <ContextMenuPrimitive.SubTrigger
+      data-slot="context-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </ContextMenuPrimitive.SubTrigger>
+  );
+}
+
+function ContextMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubContent>) {
+  return (
+    <ContextMenuPrimitive.SubContent
+      data-slot="context-menu-sub-content"
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Content
+        data-slot="context-menu-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          className,
+        )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  );
+}
+
+function ContextMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <ContextMenuPrimitive.Item
+      data-slot="context-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.CheckboxItem>) {
+  return (
+    <ContextMenuPrimitive.CheckboxItem
+      data-slot="context-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <ContextMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.CheckboxItem>
+  );
+}
+
+function ContextMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.RadioItem>) {
+  return (
+    <ContextMenuPrimitive.RadioItem
+      data-slot="context-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <ContextMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.RadioItem>
+  );
+}
+
+function ContextMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <ContextMenuPrimitive.Label
+      data-slot="context-menu-label"
+      data-inset={inset}
+      className={cn(
+        "text-foreground px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Separator>) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="context-menu-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuRadioGroup,
+};

--- a/src/app/ui/dialog.tsx
+++ b/src/app/ui/dialog.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { XIcon } from "lucide-react";
+
+import { cn } from "./utils";
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+          <XIcon />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/src/app/ui/drawer.tsx
+++ b/src/app/ui/drawer.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
+
+import { cn } from "./utils";
+
+function Drawer({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+}
+
+function DrawerTrigger({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
+}
+
+function DrawerPortal({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
+}
+
+function DrawerClose({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal data-slot="drawer-portal">
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          "group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
+          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
+          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
+          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
+          className,
+        )}
+        {...props}
+      >
+        <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  );
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+};

--- a/src/app/ui/dropdown-menu.tsx
+++ b/src/app/ui/dropdown-menu.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import * as React from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
+
+import { cn } from "./utils";
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  );
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  );
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+};

--- a/src/app/ui/form.tsx
+++ b/src/app/ui/form.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { Slot } from "@radix-ui/react-slot";
+import {
+  Controller,
+  FormProvider,
+  useFormContext,
+  useFormState,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form";
+
+import { cn } from "./utils";
+import { Label } from "./label";
+
+const Form = FormProvider;
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName;
+};
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue,
+);
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+};
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = React.useContext(FormItemContext);
+  const { getFieldState } = useFormContext();
+  const formState = useFormState({ name: fieldContext.name });
+  const fieldState = getFieldState(fieldContext.name, formState);
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>");
+  }
+
+  const { id } = itemContext;
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  };
+};
+
+type FormItemContextValue = {
+  id: string;
+};
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue,
+);
+
+function FormItem({ className, ...props }: React.ComponentProps<"div">) {
+  const id = React.useId();
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div
+        data-slot="form-item"
+        className={cn("grid gap-2", className)}
+        {...props}
+      />
+    </FormItemContext.Provider>
+  );
+}
+
+function FormLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  const { error, formItemId } = useFormField();
+
+  return (
+    <Label
+      data-slot="form-label"
+      data-error={!!error}
+      className={cn("data-[error=true]:text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  );
+}
+
+function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
+  const { error, formItemId, formDescriptionId, formMessageId } =
+    useFormField();
+
+  return (
+    <Slot
+      data-slot="form-control"
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  );
+}
+
+function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
+  const { formDescriptionId } = useFormField();
+
+  return (
+    <p
+      data-slot="form-description"
+      id={formDescriptionId}
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
+  const { error, formMessageId } = useFormField();
+  const body = error ? String(error?.message ?? "") : props.children;
+
+  if (!body) {
+    return null;
+  }
+
+  return (
+    <p
+      data-slot="form-message"
+      id={formMessageId}
+      className={cn("text-destructive text-sm", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  );
+}
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+};

--- a/src/app/ui/hover-card.tsx
+++ b/src/app/ui/hover-card.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import * as React from "react";
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
+
+import { cn } from "./utils";
+
+function HoverCard({
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
+  return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />;
+}
+
+function HoverCardTrigger({
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
+  return (
+    <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
+  );
+}
+
+function HoverCardContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
+  return (
+    <HoverCardPrimitive.Portal data-slot="hover-card-portal">
+      <HoverCardPrimitive.Content
+        data-slot="hover-card-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className,
+        )}
+        {...props}
+      />
+    </HoverCardPrimitive.Portal>
+  );
+}
+
+export { HoverCard, HoverCardTrigger, HoverCardContent };

--- a/src/app/ui/input-otp.tsx
+++ b/src/app/ui/input-otp.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import * as React from "react";
+import { OTPInput, OTPInputContext } from "input-otp";
+import { MinusIcon } from "lucide-react";
+
+import { cn } from "./utils";
+
+function InputOTP({
+  className,
+  containerClassName,
+  ...props
+}: React.ComponentProps<typeof OTPInput> & {
+  containerClassName?: string;
+}) {
+  return (
+    <OTPInput
+      data-slot="input-otp"
+      containerClassName={cn(
+        "flex items-center gap-2 has-disabled:opacity-50",
+        containerClassName,
+      )}
+      className={cn("disabled:cursor-not-allowed", className)}
+      {...props}
+    />
+  );
+}
+
+function InputOTPGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-otp-group"
+      className={cn("flex items-center gap-1", className)}
+      {...props}
+    />
+  );
+}
+
+function InputOTPSlot({
+  index,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  index: number;
+}) {
+  const inputOTPContext = React.useContext(OTPInputContext);
+  const { char, hasFakeCaret, isActive } = inputOTPContext?.slots[index] ?? {};
+
+  return (
+    <div
+      data-slot="input-otp-slot"
+      data-active={isActive}
+      className={cn(
+        "data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-9 w-9 items-center justify-center border-y border-r text-sm bg-input-background transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[3px]",
+        className,
+      )}
+      {...props}
+    >
+      {char}
+      {hasFakeCaret && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="animate-caret-blink bg-foreground h-4 w-px duration-1000" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function InputOTPSeparator({ ...props }: React.ComponentProps<"div">) {
+  return (
+    <div data-slot="input-otp-separator" role="separator" {...props}>
+      <MinusIcon />
+    </div>
+  );
+}
+
+export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator };

--- a/src/app/ui/input.tsx
+++ b/src/app/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+import { cn } from "./utils";
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base bg-input-background transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/src/app/ui/label.tsx
+++ b/src/app/ui/label.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+
+import { cn } from "./utils";
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Label };

--- a/src/app/ui/menubar.tsx
+++ b/src/app/ui/menubar.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import * as React from "react";
+import * as MenubarPrimitive from "@radix-ui/react-menubar";
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
+
+import { cn } from "./utils";
+
+function Menubar({
+  className,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Root>) {
+  return (
+    <MenubarPrimitive.Root
+      data-slot="menubar"
+      className={cn(
+        "bg-background flex h-9 items-center gap-1 rounded-md border p-1 shadow-xs",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function MenubarMenu({
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Menu>) {
+  return <MenubarPrimitive.Menu data-slot="menubar-menu" {...props} />;
+}
+
+function MenubarGroup({
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Group>) {
+  return <MenubarPrimitive.Group data-slot="menubar-group" {...props} />;
+}
+
+function MenubarPortal({
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Portal>) {
+  return <MenubarPrimitive.Portal data-slot="menubar-portal" {...props} />;
+}
+
+function MenubarRadioGroup({
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.RadioGroup>) {
+  return (
+    <MenubarPrimitive.RadioGroup data-slot="menubar-radio-group" {...props} />
+  );
+}
+
+function MenubarTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Trigger>) {
+  return (
+    <MenubarPrimitive.Trigger
+      data-slot="menubar-trigger"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex items-center rounded-sm px-2 py-1 text-sm font-medium outline-hidden select-none",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function MenubarContent({
+  className,
+  align = "start",
+  alignOffset = -4,
+  sideOffset = 8,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Content>) {
+  return (
+    <MenubarPortal>
+      <MenubarPrimitive.Content
+        data-slot="menubar-content"
+        align={align}
+        alignOffset={alignOffset}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[12rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md",
+          className,
+        )}
+        {...props}
+      />
+    </MenubarPortal>
+  );
+}
+
+function MenubarItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Item> & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <MenubarPrimitive.Item
+      data-slot="menubar-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function MenubarCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.CheckboxItem>) {
+  return (
+    <MenubarPrimitive.CheckboxItem
+      data-slot="menubar-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <MenubarPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </MenubarPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </MenubarPrimitive.CheckboxItem>
+  );
+}
+
+function MenubarRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.RadioItem>) {
+  return (
+    <MenubarPrimitive.RadioItem
+      data-slot="menubar-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <MenubarPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </MenubarPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </MenubarPrimitive.RadioItem>
+  );
+}
+
+function MenubarLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <MenubarPrimitive.Label
+      data-slot="menubar-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function MenubarSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Separator>) {
+  return (
+    <MenubarPrimitive.Separator
+      data-slot="menubar-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function MenubarShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="menubar-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function MenubarSub({
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Sub>) {
+  return <MenubarPrimitive.Sub data-slot="menubar-sub" {...props} />;
+}
+
+function MenubarSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <MenubarPrimitive.SubTrigger
+      data-slot="menubar-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[inset]:pl-8",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto h-4 w-4" />
+    </MenubarPrimitive.SubTrigger>
+  );
+}
+
+function MenubarSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.SubContent>) {
+  return (
+    <MenubarPrimitive.SubContent
+      data-slot="menubar-sub-content"
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Menubar,
+  MenubarPortal,
+  MenubarMenu,
+  MenubarTrigger,
+  MenubarContent,
+  MenubarGroup,
+  MenubarSeparator,
+  MenubarLabel,
+  MenubarItem,
+  MenubarShortcut,
+  MenubarCheckboxItem,
+  MenubarRadioGroup,
+  MenubarRadioItem,
+  MenubarSub,
+  MenubarSubTrigger,
+  MenubarSubContent,
+};

--- a/src/app/ui/navigation-menu.tsx
+++ b/src/app/ui/navigation-menu.tsx
@@ -1,0 +1,168 @@
+import * as React from "react";
+import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
+import { cva } from "class-variance-authority";
+import { ChevronDownIcon } from "lucide-react";
+
+import { cn } from "./utils";
+
+function NavigationMenu({
+  className,
+  children,
+  viewport = true,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Root> & {
+  viewport?: boolean;
+}) {
+  return (
+    <NavigationMenuPrimitive.Root
+      data-slot="navigation-menu"
+      data-viewport={viewport}
+      className={cn(
+        "group/navigation-menu relative flex max-w-max flex-1 items-center justify-center",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {viewport && <NavigationMenuViewport />}
+    </NavigationMenuPrimitive.Root>
+  );
+}
+
+function NavigationMenuList({
+  className,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.List>) {
+  return (
+    <NavigationMenuPrimitive.List
+      data-slot="navigation-menu-list"
+      className={cn(
+        "group flex flex-1 list-none items-center justify-center gap-1",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function NavigationMenuItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Item>) {
+  return (
+    <NavigationMenuPrimitive.Item
+      data-slot="navigation-menu-item"
+      className={cn("relative", className)}
+      {...props}
+    />
+  );
+}
+
+const navigationMenuTriggerStyle = cva(
+  "group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:hover:bg-accent data-[state=open]:text-accent-foreground data-[state=open]:focus:bg-accent data-[state=open]:bg-accent/50 focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1",
+);
+
+function NavigationMenuTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Trigger>) {
+  return (
+    <NavigationMenuPrimitive.Trigger
+      data-slot="navigation-menu-trigger"
+      className={cn(navigationMenuTriggerStyle(), "group", className)}
+      {...props}
+    >
+      {children}{" "}
+      <ChevronDownIcon
+        className="relative top-[1px] ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
+        aria-hidden="true"
+      />
+    </NavigationMenuPrimitive.Trigger>
+  );
+}
+
+function NavigationMenuContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Content>) {
+  return (
+    <NavigationMenuPrimitive.Content
+      data-slot="navigation-menu-content"
+      className={cn(
+        "data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 top-0 left-0 w-full p-2 pr-2.5 md:absolute md:w-auto",
+        "group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:rounded-md group-data-[viewport=false]/navigation-menu:border group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:duration-200 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function NavigationMenuViewport({
+  className,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Viewport>) {
+  return (
+    <div
+      className={cn(
+        "absolute top-full left-0 isolate z-50 flex justify-center",
+      )}
+    >
+      <NavigationMenuPrimitive.Viewport
+        data-slot="navigation-menu-viewport"
+        className={cn(
+          "origin-top-center bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border shadow md:w-[var(--radix-navigation-menu-viewport-width)]",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function NavigationMenuLink({
+  className,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Link>) {
+  return (
+    <NavigationMenuPrimitive.Link
+      data-slot="navigation-menu-link"
+      className={cn(
+        "data-[active=true]:focus:bg-accent data-[active=true]:hover:bg-accent data-[active=true]:bg-accent/50 data-[active=true]:text-accent-foreground hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-ring/50 [&_svg:not([class*='text-'])]:text-muted-foreground flex flex-col gap-1 rounded-sm p-2 text-sm transition-all outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function NavigationMenuIndicator({
+  className,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Indicator>) {
+  return (
+    <NavigationMenuPrimitive.Indicator
+      data-slot="navigation-menu-indicator"
+      className={cn(
+        "data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden",
+        className,
+      )}
+      {...props}
+    >
+      <div className="bg-border relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm shadow-md" />
+    </NavigationMenuPrimitive.Indicator>
+  );
+}
+
+export {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuContent,
+  NavigationMenuTrigger,
+  NavigationMenuLink,
+  NavigationMenuIndicator,
+  NavigationMenuViewport,
+  navigationMenuTriggerStyle,
+};

--- a/src/app/ui/pagination.tsx
+++ b/src/app/ui/pagination.tsx
@@ -1,0 +1,127 @@
+import * as React from "react";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  MoreHorizontalIcon,
+} from "lucide-react";
+
+import { cn } from "./utils";
+import { Button, buttonVariants } from "./button";
+
+function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn("mx-auto flex w-full justify-center", className)}
+      {...props}
+    />
+  );
+}
+
+function PaginationContent({
+  className,
+  ...props
+}: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn("flex flex-row items-center gap-1", className)}
+      {...props}
+    />
+  );
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<"li">) {
+  return <li data-slot="pagination-item" {...props} />;
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean;
+} & Pick<React.ComponentProps<typeof Button>, "size"> &
+  React.ComponentProps<"a">;
+
+function PaginationLink({
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) {
+  return (
+    <a
+      aria-current={isActive ? "page" : undefined}
+      data-slot="pagination-link"
+      data-active={isActive}
+      className={cn(
+        buttonVariants({
+          variant: isActive ? "outline" : "ghost",
+          size,
+        }),
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function PaginationPrevious({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pl-2.5", className)}
+      {...props}
+    >
+      <ChevronLeftIcon />
+      <span className="hidden sm:block">Previous</span>
+    </PaginationLink>
+  );
+}
+
+function PaginationNext({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pr-2.5", className)}
+      {...props}
+    >
+      <span className="hidden sm:block">Next</span>
+      <ChevronRightIcon />
+    </PaginationLink>
+  );
+}
+
+function PaginationEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontalIcon className="size-4" />
+      <span className="sr-only">More pages</span>
+    </span>
+  );
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+};

--- a/src/app/ui/popover.tsx
+++ b/src/app/ui/popover.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+
+import { cn } from "./utils";
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/src/app/ui/progress.tsx
+++ b/src/app/ui/progress.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import * as React from "react";
+import * as ProgressPrimitive from "@radix-ui/react-progress";
+
+import { cn } from "./utils";
+
+function Progress({
+  className,
+  value,
+  ...props
+}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+  return (
+    <ProgressPrimitive.Root
+      data-slot="progress"
+      className={cn(
+        "bg-primary/20 relative h-2 w-full overflow-hidden rounded-full",
+        className,
+      )}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        data-slot="progress-indicator"
+        className="bg-primary h-full w-full flex-1 transition-all"
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  );
+}
+
+export { Progress };

--- a/src/app/ui/radio-group.tsx
+++ b/src/app/ui/radio-group.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import * as React from "react";
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { CircleIcon } from "lucide-react";
+
+import { cn } from "./utils";
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid gap-3", className)}
+      {...props}
+    />
+  );
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="relative flex items-center justify-center"
+      >
+        <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+}
+
+export { RadioGroup, RadioGroupItem };

--- a/src/app/ui/resizable.tsx
+++ b/src/app/ui/resizable.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as React from "react";
+import { GripVerticalIcon } from "lucide-react";
+import * as ResizablePrimitive from "react-resizable-panels";
+
+import { cn } from "./utils";
+
+function ResizablePanelGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) {
+  return (
+    <ResizablePrimitive.PanelGroup
+      data-slot="resizable-panel-group"
+      className={cn(
+        "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ResizablePanel({
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.Panel>) {
+  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />;
+}
+
+function ResizableHandle({
+  withHandle,
+  className,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+  withHandle?: boolean;
+}) {
+  return (
+    <ResizablePrimitive.PanelResizeHandle
+      data-slot="resizable-handle"
+      className={cn(
+        "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+        className,
+      )}
+      {...props}
+    >
+      {withHandle && (
+        <div className="bg-border z-10 flex h-4 w-3 items-center justify-center rounded-xs border">
+          <GripVerticalIcon className="size-2.5" />
+        </div>
+      )}
+    </ResizablePrimitive.PanelResizeHandle>
+  );
+}
+
+export { ResizablePanelGroup, ResizablePanel, ResizableHandle };

--- a/src/app/ui/scroll-area.tsx
+++ b/src/app/ui/scroll-area.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import * as React from "react";
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
+
+import { cn } from "./utils";
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  );
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none",
+        orientation === "vertical" &&
+          "h-full w-2.5 border-l border-l-transparent",
+        orientation === "horizontal" &&
+          "h-2.5 flex-col border-t border-t-transparent",
+        className,
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="bg-border relative flex-1 rounded-full"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  );
+}
+
+export { ScrollArea, ScrollBar };

--- a/src/app/ui/select.tsx
+++ b/src/app/ui/select.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import {
+  CheckIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+} from "lucide-react";
+
+import { cn } from "./utils";
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-full items-center justify-between gap-2 rounded-md border bg-input-background px-3 py-2 text-sm whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "popper",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className,
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1",
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/src/app/ui/separator.tsx
+++ b/src/app/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import * as React from "react";
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
+
+import { cn } from "./utils";
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator-root"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator };

--- a/src/app/ui/sheet.tsx
+++ b/src/app/ui/sheet.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import * as React from "react";
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { XIcon } from "lucide-react";
+
+import { cn } from "./utils";
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left";
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          side === "right" &&
+            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+          side === "left" &&
+            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+          side === "top" &&
+            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+          side === "bottom" &&
+            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+          <XIcon className="size-4" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  );
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/src/app/ui/sidebar.tsx
+++ b/src/app/ui/sidebar.tsx
@@ -1,0 +1,726 @@
+"use client";
+
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { VariantProps, cva } from "class-variance-authority";
+import { PanelLeftIcon } from "lucide-react";
+
+import { useIsMobile } from "./use-mobile";
+import { cn } from "./utils";
+import { Button } from "./button";
+import { Input } from "./input";
+import { Separator } from "./separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "./sheet";
+import { Skeleton } from "./skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./tooltip";
+
+const SIDEBAR_COOKIE_NAME = "sidebar_state";
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+const SIDEBAR_WIDTH = "16rem";
+const SIDEBAR_WIDTH_MOBILE = "18rem";
+const SIDEBAR_WIDTH_ICON = "3rem";
+const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+
+type SidebarContextProps = {
+  state: "expanded" | "collapsed";
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  openMobile: boolean;
+  setOpenMobile: (open: boolean) => void;
+  isMobile: boolean;
+  toggleSidebar: () => void;
+};
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null);
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext);
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.");
+  }
+
+  return context;
+}
+
+function SidebarProvider({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange: setOpenProp,
+  className,
+  style,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  const isMobile = useIsMobile();
+  const [openMobile, setOpenMobile] = React.useState(false);
+
+  // This is the internal state of the sidebar.
+  // We use openProp and setOpenProp for control from outside the component.
+  const [_open, _setOpen] = React.useState(defaultOpen);
+  const open = openProp ?? _open;
+  const setOpen = React.useCallback(
+    (value: boolean | ((value: boolean) => boolean)) => {
+      const openState = typeof value === "function" ? value(open) : value;
+      if (setOpenProp) {
+        setOpenProp(openState);
+      } else {
+        _setOpen(openState);
+      }
+
+      // This sets the cookie to keep the sidebar state.
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+    },
+    [setOpenProp, open],
+  );
+
+  // Helper to toggle the sidebar.
+  const toggleSidebar = React.useCallback(() => {
+    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
+  }, [isMobile, setOpen, setOpenMobile]);
+
+  // Adds a keyboard shortcut to toggle the sidebar.
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault();
+        toggleSidebar();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [toggleSidebar]);
+
+  // We add a state so that we can do data-state="expanded" or "collapsed".
+  // This makes it easier to style the sidebar with Tailwind classes.
+  const state = open ? "expanded" : "collapsed";
+
+  const contextValue = React.useMemo<SidebarContextProps>(
+    () => ({
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+    }),
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar],
+  );
+
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <TooltipProvider delayDuration={0}>
+        <div
+          data-slot="sidebar-wrapper"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH,
+              "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+              ...style,
+            } as React.CSSProperties
+          }
+          className={cn(
+            "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </div>
+      </TooltipProvider>
+    </SidebarContext.Provider>
+  );
+}
+
+function Sidebar({
+  side = "left",
+  variant = "sidebar",
+  collapsible = "offcanvas",
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  side?: "left" | "right";
+  variant?: "sidebar" | "floating" | "inset";
+  collapsible?: "offcanvas" | "icon" | "none";
+}) {
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
+
+  if (collapsible === "none") {
+    return (
+      <div
+        data-slot="sidebar"
+        className={cn(
+          "bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <SheetContent
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+          side={side}
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <div
+      className="group peer text-sidebar-foreground hidden md:block"
+      data-state={state}
+      data-collapsible={state === "collapsed" ? collapsible : ""}
+      data-variant={variant}
+      data-side={side}
+      data-slot="sidebar"
+    >
+      {/* This is what handles the sidebar gap on desktop */}
+      <div
+        data-slot="sidebar-gap"
+        className={cn(
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "group-data-[collapsible=offcanvas]:w-0",
+          "group-data-[side=right]:rotate-180",
+          variant === "floating" || variant === "inset"
+            ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
+        )}
+      />
+      <div
+        data-slot="sidebar-container"
+        className={cn(
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          side === "left"
+            ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
+            : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
+          // Adjust the padding for floating and inset variants.
+          variant === "floating" || variant === "inset"
+            ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+          className,
+        )}
+        {...props}
+      >
+        <div
+          data-sidebar="sidebar"
+          data-slot="sidebar-inner"
+          className="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SidebarTrigger({
+  className,
+  onClick,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <Button
+      data-sidebar="trigger"
+      data-slot="sidebar-trigger"
+      variant="ghost"
+      size="icon"
+      className={cn("size-7", className)}
+      onClick={(event) => {
+        onClick?.(event);
+        toggleSidebar();
+      }}
+      {...props}
+    >
+      <PanelLeftIcon />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  );
+}
+
+function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <button
+      data-sidebar="rail"
+      data-slot="sidebar-rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
+        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
+        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+        "hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
+        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+  return (
+    <main
+      data-slot="sidebar-inset"
+      className={cn(
+        "bg-background relative flex w-full flex-1 flex-col",
+        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof Input>) {
+  return (
+    <Input
+      data-slot="sidebar-input"
+      data-sidebar="input"
+      className={cn("bg-background h-8 w-full shadow-none", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-header"
+      data-sidebar="header"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      data-sidebar="footer"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="sidebar-separator"
+      data-sidebar="separator"
+      className={cn("bg-sidebar-border mx-2 w-auto", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-content"
+      data-sidebar="content"
+      className={cn(
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group"
+      data-sidebar="group"
+      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroupLabel({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <Comp
+      data-slot="sidebar-group-label"
+      data-sidebar="group-label"
+      className={cn(
+        "text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroupAction({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      data-slot="sidebar-group-action"
+      data-sidebar="group-action"
+      className={cn(
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
+        "group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroupContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group-content"
+      data-sidebar="group-content"
+      className={cn("w-full text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      data-sidebar="menu"
+      className={cn("flex w-full min-w-0 flex-col gap-1", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      data-sidebar="menu-item"
+      className={cn("group/menu-item relative", className)}
+      {...props}
+    />
+  );
+}
+
+const sidebarMenuButtonVariants = cva(
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        outline:
+          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+      },
+      size: {
+        default: "h-8 text-sm",
+        sm: "h-7 text-xs",
+        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function SidebarMenuButton({
+  asChild = false,
+  isActive = false,
+  variant = "default",
+  size = "default",
+  tooltip,
+  className,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean;
+  isActive?: boolean;
+  tooltip?: string | React.ComponentProps<typeof TooltipContent>;
+} & VariantProps<typeof sidebarMenuButtonVariants>) {
+  const Comp = asChild ? Slot : "button";
+  const { isMobile, state } = useSidebar();
+
+  const button = (
+    <Comp
+      data-slot="sidebar-menu-button"
+      data-sidebar="menu-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
+
+  if (!tooltip) {
+    return button;
+  }
+
+  if (typeof tooltip === "string") {
+    tooltip = {
+      children: tooltip,
+    };
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent
+        side="right"
+        align="center"
+        hidden={state !== "collapsed" || isMobile}
+        {...tooltip}
+      />
+    </Tooltip>
+  );
+}
+
+function SidebarMenuAction({
+  className,
+  asChild = false,
+  showOnHover = false,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean;
+  showOnHover?: boolean;
+}) {
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-action"
+      data-sidebar="menu-action"
+      className={cn(
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
+        showOnHover &&
+          "peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuBadge({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-menu-badge"
+      data-sidebar="menu-badge"
+      className={cn(
+        "text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums select-none",
+        "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuSkeleton({
+  className,
+  showIcon = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showIcon?: boolean;
+}) {
+  // Random width between 50 to 90%.
+  const width = React.useMemo(() => {
+    return `${Math.floor(Math.random() * 40) + 50}%`;
+  }, []);
+
+  return (
+    <div
+      data-slot="sidebar-menu-skeleton"
+      data-sidebar="menu-skeleton"
+      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+      {...props}
+    >
+      {showIcon && (
+        <Skeleton
+          className="size-4 rounded-md"
+          data-sidebar="menu-skeleton-icon"
+        />
+      )}
+      <Skeleton
+        className="h-4 max-w-(--skeleton-width) flex-1"
+        data-sidebar="menu-skeleton-text"
+        style={
+          {
+            "--skeleton-width": width,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  );
+}
+
+function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu-sub"
+      data-sidebar="menu-sub"
+      className={cn(
+        "border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5",
+        "group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuSubItem({
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-sub-item"
+      data-sidebar="menu-sub-item"
+      className={cn("group/menu-sub-item relative", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuSubButton({
+  asChild = false,
+  size = "md",
+  isActive = false,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean;
+  size?: "sm" | "md";
+  isActive?: boolean;
+}) {
+  const Comp = asChild ? Slot : "a";
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-sub-button"
+      data-sidebar="menu-sub-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+        "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
+        size === "sm" && "text-xs",
+        size === "md" && "text-sm",
+        "group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+};

--- a/src/app/ui/skeleton.tsx
+++ b/src/app/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "./utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("bg-accent animate-pulse rounded-md", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/src/app/ui/slider.tsx
+++ b/src/app/ui/slider.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import * as React from "react";
+import * as SliderPrimitive from "@radix-ui/react-slider";
+
+import { cn } from "./utils";
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  const _values = React.useMemo(
+    () =>
+      Array.isArray(value)
+        ? value
+        : Array.isArray(defaultValue)
+          ? defaultValue
+          : [min, max],
+    [value, defaultValue, min, max],
+  );
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+        className,
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className={cn(
+          "bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-4 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5",
+        )}
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className={cn(
+            "bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full",
+          )}
+        />
+      </SliderPrimitive.Track>
+      {Array.from({ length: _values.length }, (_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot="slider-thumb"
+          key={index}
+          className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  );
+}
+
+export { Slider };

--- a/src/app/ui/sonner.tsx
+++ b/src/app/ui/sonner.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Toaster as Sonner, ToasterProps } from "sonner";
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme();
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/src/app/ui/switch.tsx
+++ b/src/app/ui/switch.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import * as React from "react";
+import * as SwitchPrimitive from "@radix-ui/react-switch";
+
+import { cn } from "./utils";
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-switch-background focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-card dark:data-[state=unchecked]:bg-card-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0",
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/src/app/ui/table.tsx
+++ b/src/app/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "./utils";
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  );
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  );
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+};

--- a/src/app/ui/tabs.tsx
+++ b/src/app/ui/tabs.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+
+import { cn } from "./utils";
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-xl p-[3px] flex",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "data-[state=active]:bg-card dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-xl border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/src/app/ui/textarea.tsx
+++ b/src/app/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { cn } from "./utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "resize-none border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-input-background px-3 py-2 text-base transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/src/app/ui/toggle-group.tsx
+++ b/src/app/ui/toggle-group.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import * as React from "react";
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
+import { type VariantProps } from "class-variance-authority";
+
+import { cn } from "./utils";
+import { toggleVariants } from "./toggle";
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants>
+>({
+  size: "default",
+  variant: "default",
+});
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <ToggleGroupPrimitive.Root
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      className={cn(
+        "group/toggle-group flex w-fit items-center rounded-md data-[variant=outline]:shadow-xs",
+        className,
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  );
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+  VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext);
+
+  return (
+    <ToggleGroupPrimitive.Item
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        "min-w-0 flex-1 shrink-0 rounded-none shadow-none first:rounded-l-md last:rounded-r-md focus:z-10 focus-visible:z-10 data-[variant=outline]:border-l-0 data-[variant=outline]:first:border-l",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  );
+}
+
+export { ToggleGroup, ToggleGroupItem };

--- a/src/app/ui/toggle.tsx
+++ b/src/app/ui/toggle.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import * as React from "react";
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "./utils";
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 px-2 min-w-9",
+        sm: "h-8 px-1.5 min-w-8",
+        lg: "h-10 px-2.5 min-w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Toggle({
+  className,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Toggle, toggleVariants };

--- a/src/app/ui/tooltip.tsx
+++ b/src/app/ui/tooltip.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+import { cn } from "./utils";
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  );
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  );
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/src/app/ui/use-mobile.ts
+++ b/src/app/ui/use-mobile.ts
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
+    undefined,
+  );
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    };
+    mql.addEventListener("change", onChange);
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return !!isMobile;
+}

--- a/src/app/ui/utils.ts
+++ b/src/app/ui/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## 🔎개요
전체 UI 리디자인 — 랜딩 페이지 신규 추가, 로그인 화면 개편, 대시보드/뷰어/히스토리 컴포넌트 UI 업데이트

<br/>

## 📝작업 내용
- **신규 컴포넌트 추가**
  - `LandingPage.tsx` — 서비스 소개용 랜딩 페이지
  - `LoginPreview3D.tsx` — 로그인 화면에 표시되는 3D 프리뷰 컴포넌트
- **기존 컴포넌트 UI 개편**
  - `LoginScreen.tsx` — 로그인 화면 디자인 전면 개편
  - `Dashboard.tsx` — 대시보드 레이아웃/스타일 업데이트
  - `AnalysisHistory.tsx` — 히스토리 화면 UI 개선
  - `Viewer3D.tsx` — 3D 뷰어 UI 조정
- **라우팅/엔트리 수정**
  - `App.tsx` — 신규 페이지 라우팅 연결
  - `OAuthCallback.tsx` — 콜백 페이지 마이너 업데이트
  - `index.html` — 메타 정보 / 에셋 참조 업데이트
- **에셋 추가**
  - `public/rescene-logo.png`, `public/rs-mark.png` — 신규 로고/마크

<br/>

## 👀변경 사항
- `LandingPage`, `LoginPreview3D`가 새로 추가되었으므로 `App.tsx`의 라우팅 구조 변경 확인 필요
- 로고 에셋 경로(`/rescene-logo.png`, `/rs-mark.png`)가 새로 추가됨 — 빌드 시 `public/` 정상 포함되는지 확인
- 기존 컴포넌트의 props/state 인터페이스는 유지, 내부 마크업/스타일만 변경

<br/>

## 📸UI 스크린샷
<img width="2520" height="1218" alt="image" src="https://github.com/user-attachments/assets/0e97bf41-ea00-4cac-89a6-d209341b7261" />
<img width="2463" height="1100" alt="image" src="https://github.com/user-attachments/assets/7b550ca5-8b94-426c-8a24-2d3972b126cc" />

